### PR TITLE
Stage B MIDI-to-solo interval contour aftercare objective-only next decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- interval contour aftercare input guard: schema matched `true`, pending candidate fields `24`, next `objective_only_next_decision`
+- interval contour aftercare objective decision: residual labels `0`, next `listening_review`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -158,6 +158,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_input_guard`
 - interval contour aftercare listening input guard: schema matched `true`, pending candidate fields `24`, objective-only next decision required `true`
 - next boundary: `music_transformer_solo_yield_interval_contour_aftercare_objective_only_next_decision`
+- interval contour aftercare objective-only decision: MIDI low chord-tone ratio `0 / 8`, low note count `0 / 8`, wide interval review `0 / 8`, dead-air aftercare `0 / 8`
+- next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
 
 ## 결과 파일
 
@@ -180,6 +182,7 @@ Report:
 - `outputs/music_transformer_finetune_mvp/solo_yield_final_status_audit/issue_1256_final_status_audit/final_status_audit.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_final_status_audit/issue_1256_final_status_audit/final_status_audit_summary.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1254_4bar_repaired_objective_next_decision/objective_next_decision.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_objective_next/issue_1312_interval_contour_objective_next/interval_contour_aftercare_objective_next_decision.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -223,6 +226,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_LISTENING_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_LISTENING_INPUT_GUARD_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_OBJECTIVE_NEXT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_OBJECTIVE_NEXT_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_OBJECTIVE_NEXT_2026-06-11.md
@@ -1,0 +1,90 @@
+# Music Transformer Solo Yield Interval Contour Aftercare Objective-Only Next Decision
+
+## Summary
+
+- boundary: `music_transformer_solo_yield_interval_contour_aftercare_objective_only_next_decision`
+- candidate count: `8`
+- MIDI low chord-tone ratio: `0`
+- low note count for 4bar: `0`
+- wide interval review: `0`
+- dead-air aftercare: `0`
+- weak direction-change: `0`
+- final landing not chord-tone: `0`
+- direction-change min/avg: `0.5000` / `0.5667`
+- chord-tone ratio min/avg/max: `0.5000` / `0.5331` / `0.6333`
+- note count min/max: `30` / `34`
+- max interval: `7`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- selected next target: `listening_review_required`
+- next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
+- musical quality claimed: `false`
+
+## Residual Label Counts
+
+
+## Candidates
+
+- candidate `1` / `minor_backdoor`
+  - labels: `none`
+  - chord-tone ratio: `0.5152`
+  - direction-change ratio: `0.5806`
+  - max gap seconds: `0.6048`
+  - note count: `33`
+  - max interval: `7`
+- candidate `2` / `minor_backdoor`
+  - labels: `none`
+  - chord-tone ratio: `0.5000`
+  - direction-change ratio: `0.5862`
+  - max gap seconds: `0.4839`
+  - note count: `34`
+  - max interval: `7`
+- candidate `3` / `major_ii_v_turnaround`
+  - labels: `none`
+  - chord-tone ratio: `0.5000`
+  - direction-change ratio: `0.6071`
+  - max gap seconds: `0.4839`
+  - note count: `32`
+  - max interval: `7`
+- candidate `4` / `major_ii_v_turnaround`
+  - labels: `none`
+  - chord-tone ratio: `0.5000`
+  - direction-change ratio: `0.5333`
+  - max gap seconds: `0.6048`
+  - note count: `32`
+  - max interval: `7`
+- candidate `5` / `dominant_cycle`
+  - labels: `none`
+  - chord-tone ratio: `0.5667`
+  - direction-change ratio: `0.5556`
+  - max gap seconds: `0.6048`
+  - note count: `30`
+  - max interval: `7`
+- candidate `6` / `dominant_cycle`
+  - labels: `none`
+  - chord-tone ratio: `0.6333`
+  - direction-change ratio: `0.5556`
+  - max gap seconds: `0.4839`
+  - note count: `30`
+  - max interval: `7`
+- candidate `7` / `rhythm_turnaround`
+  - labels: `none`
+  - chord-tone ratio: `0.5333`
+  - direction-change ratio: `0.6154`
+  - max gap seconds: `0.6048`
+  - note count: `30`
+  - max interval: `7`
+- candidate `8` / `rhythm_turnaround`
+  - labels: `none`
+  - chord-tone ratio: `0.5161`
+  - direction-change ratio: `0.5000`
+  - max gap seconds: `0.6048`
+  - note count: `31`
+  - max interval: `7`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/decide_music_transformer_solo_yield_interval_contour_aftercare_objective_next.py
+++ b/scripts/decide_music_transformer_solo_yield_interval_contour_aftercare_objective_next.py
@@ -1,0 +1,462 @@
+"""Decide next repair target after interval-contour-aftercare repair from objective evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.guard_music_transformer_solo_yield_interval_contour_aftercare_listening_input import (  # noqa: E402
+    SCHEMA_VERSION as INPUT_GUARD_SCHEMA_VERSION,
+)
+from scripts.run_music_transformer_solo_yield_interval_contour_aftercare_sweep import (  # noqa: E402
+    SCHEMA_VERSION as REPAIR_SWEEP_SCHEMA_VERSION,
+)
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_interval_contour_aftercare_objective_next_v1"
+BOUNDARY = "music_transformer_solo_yield_interval_contour_aftercare_objective_only_next_decision"
+NEXT_BOUNDARY_INTERVAL_CONTOUR_AFTERCARE = "music_transformer_solo_yield_interval_contour_aftercare_sweep"
+NEXT_BOUNDARY_INTERVAL_CONTOUR = "music_transformer_solo_yield_interval_contour_aftercare_sweep"
+NEXT_BOUNDARY_DENSITY_AFTERCARE = "music_transformer_solo_yield_density_aftercare_sweep"
+NEXT_BOUNDARY_CHORD_ROLE_BALANCE = "music_transformer_solo_yield_chord_role_balance_repair_sweep"
+NEXT_BOUNDARY_LISTENING_REVIEW = "music_transformer_solo_yield_interval_contour_aftercare_listening_review"
+NEXT_BOUNDARY_LISTENING_REVIEW_FILL = (
+    "music_transformer_solo_yield_interval_contour_aftercare_listening_review_fill"
+)
+
+
+class SoloYieldIntervalContourAftercareObjectiveNextError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldIntervalContourAftercareObjectiveNextError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_no_quality_claim(readiness: dict[str, Any]) -> None:
+    claimed = [
+        key
+        for key in (
+            "audio_rendered_quality_claimed",
+            "musical_quality_claimed",
+            "artist_style_claimed",
+            "production_ready_claimed",
+        )
+        if bool(readiness.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError(f"unexpected quality claim: {claimed}")
+
+
+def validate_guard_report(guard_report: dict[str, Any]) -> dict[str, Any]:
+    if str(guard_report.get("schema_version") or "") != INPUT_GUARD_SCHEMA_VERSION:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("input guard schema required")
+    readiness = _dict(guard_report.get("readiness"))
+    _require_no_quality_claim(readiness)
+    input_validation = _dict(guard_report.get("input_validation"))
+    return {
+        "validated_listening_input_present": bool(
+            input_validation.get("validated_listening_input_present", False)
+        ),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", False)),
+        "objective_only_next_decision_required": bool(
+            readiness.get("objective_only_next_decision_required", False)
+        ),
+        "pending_candidate_field_count": _int(
+            input_validation.get("pending_candidate_field_count")
+        ),
+    }
+
+
+def validate_repair_sweep(repair_sweep: dict[str, Any]) -> list[dict[str, Any]]:
+    if str(repair_sweep.get("schema_version") or "") != REPAIR_SWEEP_SCHEMA_VERSION:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("repair sweep schema required")
+    readiness = _dict(repair_sweep.get("readiness"))
+    _require_no_quality_claim(readiness)
+    aggregate = _dict(repair_sweep.get("aggregate"))
+    if not bool(aggregate.get("target_supported", False)):
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("completed interval contour aftercare required")
+    if _int(aggregate.get("midi_low_chord_tone_ratio_count_after")) != 0:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("low chord-tone residual risk must be zero")
+    if _int(aggregate.get("low_note_count_after")) != 0:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("low note-count residual risk must be zero")
+    if _int(aggregate.get("dead_air_aftercare_count_after")) != 0:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("dead-air residual risk must be zero")
+    if _int(aggregate.get("chord_tone_ratio_decrease_count")) != 0:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("chord-tone ratio decrease must be zero")
+    if _int(aggregate.get("weak_direction_change_count_after")) != 0:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("weak direction residual risk must be zero")
+    if _int(aggregate.get("final_landing_not_chord_tone_count_after")) != 0:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("final landing residual risk must be zero")
+    if _int(aggregate.get("wide_interval_review_count_after")) != 0:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("wide interval residual risk must be zero")
+    rows = [_dict(row) for row in _list(repair_sweep.get("candidate_repairs"))]
+    if not rows:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("repair rows required")
+    return rows
+
+
+def residual_labels(after_profile: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    if not bool(after_profile.get("final_landing_is_chord_tone", False)):
+        labels.append("final_landing_not_chord_tone")
+    if _float(after_profile.get("midi_chord_tone_ratio")) < 0.50:
+        labels.append("midi_low_chord_tone_ratio")
+    if _float(after_profile.get("midi_max_gap_seconds")) >= 0.65:
+        labels.append("dead_air_aftercare")
+    if _float(after_profile.get("midi_direction_change_ratio")) < 0.50:
+        labels.append("weak_direction_change")
+    if _int(after_profile.get("midi_note_count")) < 30:
+        labels.append("low_note_count_for_4bar")
+    if _int(after_profile.get("midi_max_abs_interval")) >= 8:
+        labels.append("wide_interval_review")
+    return labels
+
+
+def build_residual_rows(repair_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in repair_rows:
+        after = _dict(row.get("after_profile"))
+        labels = residual_labels(after)
+        rows.append(
+            {
+                "review_index": _int(row.get("review_index")),
+                "case_label": str(row.get("case_label") or ""),
+                "repaired_midi_path": str(row.get("repaired_midi_path") or ""),
+                "source_wav_path": str(row.get("source_wav_path") or ""),
+                "after_profile": after,
+                "residual_labels": labels,
+            }
+        )
+    return rows
+
+
+def aggregate_residuals(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    label_counts: Counter[str] = Counter()
+    for row in rows:
+        label_counts.update(str(label) for label in _list(row.get("residual_labels")))
+    chord_tone = [_float(_dict(row.get("after_profile")).get("midi_chord_tone_ratio")) for row in rows]
+    max_gap = [_float(_dict(row.get("after_profile")).get("midi_max_gap_seconds")) for row in rows]
+    direction = [
+        _float(_dict(row.get("after_profile")).get("midi_direction_change_ratio")) for row in rows
+    ]
+    note_counts = [_int(_dict(row.get("after_profile")).get("midi_note_count")) for row in rows]
+    intervals = [_int(_dict(row.get("after_profile")).get("midi_max_abs_interval")) for row in rows]
+    return {
+        "candidate_count": len(rows),
+        "residual_label_counts": dict(sorted(label_counts.items())),
+        "final_landing_not_chord_tone_count": label_counts.get("final_landing_not_chord_tone", 0),
+        "midi_low_chord_tone_ratio_count": label_counts.get("midi_low_chord_tone_ratio", 0),
+        "dead_air_aftercare_count": label_counts.get("dead_air_aftercare", 0),
+        "weak_direction_change_count": label_counts.get("weak_direction_change", 0),
+        "low_note_count_for_4bar_count": label_counts.get("low_note_count_for_4bar", 0),
+        "wide_interval_review_count": label_counts.get("wide_interval_review", 0),
+        "midi_chord_tone_ratio_min": min(chord_tone, default=0.0),
+        "midi_chord_tone_ratio_max": max(chord_tone, default=0.0),
+        "midi_chord_tone_ratio_avg": float(mean(chord_tone)) if chord_tone else 0.0,
+        "midi_max_gap_seconds_max": max(max_gap, default=0.0),
+        "midi_direction_change_ratio_min": min(direction, default=0.0),
+        "midi_direction_change_ratio_avg": float(mean(direction)) if direction else 0.0,
+        "midi_note_count_min": min(note_counts, default=0),
+        "midi_note_count_max": max(note_counts, default=0),
+        "midi_max_abs_interval_max": max(intervals, default=0),
+    }
+
+
+def select_next_target(aggregate: dict[str, Any]) -> tuple[str, str, str]:
+    low_chord = _int(aggregate.get("midi_low_chord_tone_ratio_count"))
+    low_note = _int(aggregate.get("low_note_count_for_4bar_count"))
+    wide_interval = _int(aggregate.get("wide_interval_review_count"))
+    dead_air = _int(aggregate.get("dead_air_aftercare_count"))
+    if low_chord > 0:
+        return (
+            "chord_role_balance_repair",
+            NEXT_BOUNDARY_CHORD_ROLE_BALANCE,
+            "low MIDI chord-tone ratio remains after interval contour aftercare",
+        )
+    if low_note > 0 and low_note >= max(wide_interval, dead_air):
+        return (
+            "density_aftercare",
+            NEXT_BOUNDARY_DENSITY_AFTERCARE,
+            "low note-count candidates are the largest remaining objective residual",
+        )
+    if wide_interval > 0:
+        return (
+            "interval_contour_aftercare",
+            NEXT_BOUNDARY_INTERVAL_CONTOUR,
+            "wide interval review count remains after interval contour aftercare",
+        )
+    return (
+        "listening_review_required",
+        NEXT_BOUNDARY_LISTENING_REVIEW,
+        "objective residual risk below repair threshold; listening review required",
+    )
+
+
+def build_decision(
+    repair_sweep: dict[str, Any],
+    guard_report: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    guard_validation = validate_guard_report(guard_report)
+    repair_rows = validate_repair_sweep(repair_sweep)
+    residual_rows = build_residual_rows(repair_rows)
+    aggregate = aggregate_residuals(residual_rows)
+    if guard_validation["preference_fill_allowed"]:
+        selected_target = "listening_review_fill"
+        next_boundary = NEXT_BOUNDARY_LISTENING_REVIEW_FILL
+        reason = "validated listening input present"
+    else:
+        selected_target, next_boundary, reason = select_next_target(aggregate)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_repair_sweep": {
+            "schema_version": repair_sweep.get("schema_version"),
+            "output_dir": repair_sweep.get("output_dir"),
+            "candidate_count": _int(_dict(repair_sweep.get("aggregate")).get("candidate_count")),
+            "midi_low_chord_tone_ratio_count_after": _int(
+                _dict(repair_sweep.get("aggregate")).get("midi_low_chord_tone_ratio_count_after")
+            ),
+            "low_note_count_after": _int(
+                _dict(repair_sweep.get("aggregate")).get("low_note_count_after")
+            ),
+            "dead_air_aftercare_count_after": _int(
+                _dict(repair_sweep.get("aggregate")).get("dead_air_aftercare_count_after")
+            ),
+            "chord_tone_ratio_decrease_count": _int(
+                _dict(repair_sweep.get("aggregate")).get("chord_tone_ratio_decrease_count")
+            ),
+            "weak_direction_change_count_after": _int(
+                _dict(repair_sweep.get("aggregate")).get("weak_direction_change_count_after")
+            ),
+            "final_landing_not_chord_tone_count_after": _int(
+                _dict(repair_sweep.get("aggregate")).get("final_landing_not_chord_tone_count_after")
+            ),
+            "wide_interval_review_count_after": _int(
+                _dict(repair_sweep.get("aggregate")).get("wide_interval_review_count_after")
+            ),
+        },
+        "source_guard": {
+            "schema_version": guard_report.get("schema_version"),
+            "output_dir": guard_report.get("output_dir"),
+            "validated_listening_input_present": guard_validation[
+                "validated_listening_input_present"
+            ],
+            "preference_fill_allowed": guard_validation["preference_fill_allowed"],
+            "pending_candidate_field_count": guard_validation["pending_candidate_field_count"],
+        },
+        "candidate_residuals": residual_rows,
+        "aggregate": aggregate,
+        "readiness": {
+            "objective_only_next_decision_completed": True,
+            "validated_listening_input_present": guard_validation[
+                "validated_listening_input_present"
+            ],
+            "preference_fill_allowed": guard_validation["preference_fill_allowed"],
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "selected_next_target": selected_target,
+            "next_boundary": next_boundary,
+            "critical_user_input_required": False,
+            "reason": reason,
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "artist_level_long_solo_generation",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "interval_contour_aftercare_objective_next_decision.json", report)
+    write_json(
+        output_dir / "interval_contour_aftercare_objective_next_decision_summary.json",
+        validate_report(report, require_no_quality_claim=True),
+    )
+    write_text(output_dir / "interval_contour_aftercare_objective_next_decision.md", markdown_report(report))
+    return report
+
+
+def validate_report(report: dict[str, Any], *, require_no_quality_claim: bool) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldIntervalContourAftercareObjectiveNextError("schema version mismatch")
+    readiness = _dict(report.get("readiness"))
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness)
+    aggregate = _dict(report.get("aggregate"))
+    decision = _dict(report.get("decision"))
+    return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "boundary": str(report.get("boundary") or ""),
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "midi_low_chord_tone_ratio_count": _int(
+            aggregate.get("midi_low_chord_tone_ratio_count")
+        ),
+        "low_note_count_for_4bar_count": _int(
+            aggregate.get("low_note_count_for_4bar_count")
+        ),
+        "wide_interval_review_count": _int(aggregate.get("wide_interval_review_count")),
+        "dead_air_aftercare_count": _int(aggregate.get("dead_air_aftercare_count")),
+        "weak_direction_change_count": _int(aggregate.get("weak_direction_change_count")),
+        "final_landing_not_chord_tone_count": _int(
+            aggregate.get("final_landing_not_chord_tone_count")
+        ),
+        "validated_listening_input_present": bool(
+            readiness.get("validated_listening_input_present", True)
+        ),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "selected_next_target": str(decision.get("selected_next_target") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Music Transformer Solo Yield Interval Contour Aftercare Objective-Only Next Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- MIDI low chord-tone ratio: `{aggregate['midi_low_chord_tone_ratio_count']}`",
+        f"- low note count for 4bar: `{aggregate['low_note_count_for_4bar_count']}`",
+        f"- wide interval review: `{aggregate['wide_interval_review_count']}`",
+        f"- dead-air aftercare: `{aggregate['dead_air_aftercare_count']}`",
+        f"- weak direction-change: `{aggregate['weak_direction_change_count']}`",
+        f"- final landing not chord-tone: `{aggregate['final_landing_not_chord_tone_count']}`",
+        f"- direction-change min/avg: `{float(aggregate['midi_direction_change_ratio_min']):.4f}` / `{float(aggregate['midi_direction_change_ratio_avg']):.4f}`",
+        f"- chord-tone ratio min/avg/max: `{float(aggregate['midi_chord_tone_ratio_min']):.4f}` / `{float(aggregate['midi_chord_tone_ratio_avg']):.4f}` / `{float(aggregate['midi_chord_tone_ratio_max']):.4f}`",
+        f"- note count min/max: `{aggregate['midi_note_count_min']}` / `{aggregate['midi_note_count_max']}`",
+        f"- max interval: `{aggregate['midi_max_abs_interval_max']}`",
+        f"- validated listening input present: `{_bool_token(readiness['validated_listening_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(readiness['preference_fill_allowed'])}`",
+        f"- selected next target: `{decision['selected_next_target']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        "",
+        "## Residual Label Counts",
+        "",
+    ]
+    for label, count in sorted(_dict(aggregate.get("residual_label_counts")).items()):
+        lines.append(f"- `{label}`: `{count}`")
+    lines.extend(["", "## Candidates", ""])
+    for row in report.get("candidate_residuals", []):
+        profile = row["after_profile"]
+        labels = ", ".join(f"`{label}`" for label in row["residual_labels"]) or "`none`"
+        lines.extend(
+            [
+                f"- candidate `{row['review_index']}` / `{row['case_label']}`",
+                f"  - labels: {labels}",
+                f"  - chord-tone ratio: `{float(profile['midi_chord_tone_ratio']):.4f}`",
+                f"  - direction-change ratio: `{float(profile['midi_direction_change_ratio']):.4f}`",
+                f"  - max gap seconds: `{float(profile['midi_max_gap_seconds']):.4f}`",
+                f"  - note count: `{profile['midi_note_count']}`",
+                f"  - max interval: `{profile['midi_max_abs_interval']}`",
+            ]
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Decide objective next target after interval contour aftercare")
+    parser.add_argument(
+        "--repair_sweep_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare/"
+            "issue_1304_interval_contour_aftercare_sweep/interval_contour_aftercare_sweep.json"
+        ),
+    )
+    parser.add_argument(
+        "--guard_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/"
+            "solo_yield_interval_contour_aftercare_listening_input_guard/"
+            "issue_1310_interval_contour_input_guard/"
+            "interval_contour_aftercare_listening_input_guard.json"
+        ),
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_objective_next",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_decision(
+        read_json(Path(args.repair_sweep_report)),
+        read_json(Path(args.guard_report)),
+        output_dir=output_dir,
+    )
+    summary = validate_report(report, require_no_quality_claim=bool(args.require_no_quality_claim))
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_interval_contour_aftercare_objective_next.py
+++ b/tests/test_music_transformer_solo_yield_interval_contour_aftercare_objective_next.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.decide_music_transformer_solo_yield_interval_contour_aftercare_objective_next import (
+    BOUNDARY,
+    NEXT_BOUNDARY_DENSITY_AFTERCARE,
+    NEXT_BOUNDARY_INTERVAL_CONTOUR,
+    NEXT_BOUNDARY_LISTENING_REVIEW,
+    NEXT_BOUNDARY_LISTENING_REVIEW_FILL,
+    SCHEMA_VERSION,
+    build_decision,
+    validate_report,
+)
+from scripts.guard_music_transformer_solo_yield_interval_contour_aftercare_listening_input import (
+    SCHEMA_VERSION as INPUT_GUARD_SCHEMA_VERSION,
+)
+from scripts.run_music_transformer_solo_yield_interval_contour_aftercare_sweep import (
+    SCHEMA_VERSION as REPAIR_SWEEP_SCHEMA_VERSION,
+)
+
+
+def after_profile(
+    *,
+    chord_tone_ratio: float = 0.55,
+    note_count: int = 32,
+    direction_change_ratio: float = 0.56,
+    max_gap: float = 0.55,
+    max_interval: int = 7,
+) -> dict:
+    return {
+        "midi_note_count": note_count,
+        "midi_unique_pitch_count": 12,
+        "midi_pitch_span": 14,
+        "midi_max_abs_interval": max_interval,
+        "midi_direction_change_ratio": direction_change_ratio,
+        "midi_max_gap_seconds": max_gap,
+        "midi_avg_gap_seconds": 0.25,
+        "midi_chord_tone_ratio": chord_tone_ratio,
+        "midi_tension_ratio": 1.0 - chord_tone_ratio,
+        "final_landing_chord": "Ebmaj7",
+        "final_landing_pitch": 63,
+        "final_landing_is_chord_tone": True,
+    }
+
+
+def repair_sweep(rows: list[dict]) -> dict:
+    return {
+        "schema_version": REPAIR_SWEEP_SCHEMA_VERSION,
+        "output_dir": "outputs/repair",
+        "candidate_repairs": [
+            {
+                "review_index": index + 1,
+                "case_label": f"case_{index + 1}",
+                "repaired_midi_path": f"outputs/repair/candidate_{index + 1}.mid",
+                "source_wav_path": f"outputs/repair/candidate_{index + 1}.wav",
+                "after_profile": row,
+            }
+            for index, row in enumerate(rows)
+        ],
+        "aggregate": {
+            "candidate_count": len(rows),
+            "target_supported": True,
+            "midi_low_chord_tone_ratio_count_after": 0,
+            "low_note_count_after": 0,
+            "dead_air_aftercare_count_after": 0,
+            "chord_tone_ratio_decrease_count": 0,
+            "weak_direction_change_count_after": 0,
+            "final_landing_not_chord_tone_count_after": 0,
+            "wide_interval_review_count_after": 0,
+        },
+        "readiness": {
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def guard_report(*, preference_fill_allowed: bool = False) -> dict:
+    return {
+        "schema_version": INPUT_GUARD_SCHEMA_VERSION,
+        "output_dir": "outputs/guard",
+        "input_validation": {
+            "validated_listening_input_present": preference_fill_allowed,
+            "pending_candidate_field_count": 0 if preference_fill_allowed else 12,
+        },
+        "readiness": {
+            "preference_fill_allowed": preference_fill_allowed,
+            "objective_only_next_decision_required": not preference_fill_allowed,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldIntervalContourAftercareObjectiveNextTest(unittest.TestCase):
+    def test_selects_density_aftercare_when_low_note_count_is_largest_residual(self) -> None:
+        rows = [
+            after_profile(note_count=29),
+            after_profile(note_count=28),
+            after_profile(max_interval=8),
+            after_profile(),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_decision(repair_sweep(rows), guard_report(), output_dir=Path(temp_dir))
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["boundary"], BOUNDARY)
+        self.assertEqual(summary["candidate_count"], 4)
+        self.assertEqual(summary["midi_low_chord_tone_ratio_count"], 0)
+        self.assertEqual(summary["low_note_count_for_4bar_count"], 2)
+        self.assertEqual(summary["wide_interval_review_count"], 1)
+        self.assertEqual(summary["selected_next_target"], "density_aftercare")
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY_DENSITY_AFTERCARE)
+        self.assertFalse(summary["musical_quality_claimed"])
+
+    def test_selects_interval_contour_when_wide_interval_is_only_residual(self) -> None:
+        rows = [
+            after_profile(max_interval=8),
+            after_profile(max_interval=8),
+            after_profile(max_interval=7),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_decision(repair_sweep(rows), guard_report(), output_dir=Path(temp_dir))
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertEqual(summary["wide_interval_review_count"], 2)
+        self.assertEqual(summary["selected_next_target"], "interval_contour_aftercare")
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY_INTERVAL_CONTOUR)
+
+    def test_selects_listening_review_when_objective_residuals_are_clear(self) -> None:
+        rows = [
+            after_profile(chord_tone_ratio=0.50, note_count=30, max_interval=7),
+            after_profile(chord_tone_ratio=0.63, note_count=34, max_interval=7),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_decision(repair_sweep(rows), guard_report(), output_dir=Path(temp_dir))
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertEqual(summary["midi_low_chord_tone_ratio_count"], 0)
+        self.assertEqual(summary["low_note_count_for_4bar_count"], 0)
+        self.assertEqual(summary["wide_interval_review_count"], 0)
+        self.assertEqual(summary["selected_next_target"], "listening_review_required")
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY_LISTENING_REVIEW)
+
+    def test_validated_input_routes_to_listening_review_fill(self) -> None:
+        rows = [
+            after_profile(note_count=29),
+            after_profile(max_interval=8),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_decision(
+                repair_sweep(rows),
+                guard_report(preference_fill_allowed=True),
+                output_dir=Path(temp_dir),
+            )
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertTrue(summary["validated_listening_input_present"])
+        self.assertTrue(summary["preference_fill_allowed"])
+        self.assertEqual(summary["selected_next_target"], "listening_review_fill")
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY_LISTENING_REVIEW_FILL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- interval contour aftercare objective-only next decision 추가
- pending listening input guard와 repair sweep schema 검증
- residual label 재집계
- next boundary 기록
- README 최신 evidence 갱신

## Context

- #1310 input guard 결과
- candidate count: `8`
- schema matched: `true`
- validated listening input: `false`
- preference fill allowed: `false`
- objective-only next decision required: `true`
- pending candidate field count: `24`

## Scope

- interval contour aftercare sweep 결과 검증
- low chord-tone, low note, dead-air, weak direction, final landing, wide interval residual 재집계
- pending input 기준 preference fill 차단 유지
- selected next target 기록
- README evidence 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_music_transformer_solo_yield_interval_contour_aftercare_objective_next.py`
- `.venv/bin/python scripts/decide_music_transformer_solo_yield_interval_contour_aftercare_objective_next.py --run_id issue_1312_interval_contour_objective_next --doc_path docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_OBJECTIVE_NEXT_2026-06-11.md --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- candidate count: `8`
- MIDI low chord-tone ratio count: `0`
- low note count for 4bar: `0`
- wide interval review count: `0`
- dead-air aftercare count: `0`
- weak direction-change count: `0`
- final landing not chord-tone count: `0`
- validated listening input present: `false`
- preference fill allowed: `false`
- selected next target: `listening_review_required`
- next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
- musical quality claim: `false`

## Risk

- 청취 선호 입력 미포함
- 음악적 품질 판단 범위 제외
- objective metric 기준 repair residual 0과 실제 청취 품질은 별도 검토 대상

## Follow-up

- interval contour aftercare listening review package refresh or final evidence consolidation

Closes #1312