### PR TITLE
Stage B MIDI-to-solo interval contour final review handoff package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- interval contour aftercare objective decision: residual labels `0`, next `listening_review`
+- interval contour final handoff: MIDI `8`, WAV `8`, objective residual labels `0`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -160,11 +160,15 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_interval_contour_aftercare_objective_only_next_decision`
 - interval contour aftercare objective-only decision: MIDI low chord-tone ratio `0 / 8`, low note count `0 / 8`, wide interval review `0 / 8`, dead-air aftercare `0 / 8`
 - next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
+- interval contour final review handoff: MIDI `8`, WAV `8`, objective residual labels `0`, preference fill `false`
+- next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
 
 ## 결과 파일
 
 최신 리뷰 패키지:
 
+- `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`
@@ -183,6 +187,7 @@ Report:
 - `outputs/music_transformer_finetune_mvp/solo_yield_final_status_audit/issue_1256_final_status_audit/final_status_audit_summary.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1254_4bar_repaired_objective_next_decision/objective_next_decision.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_objective_next/issue_1312_interval_contour_objective_next/interval_contour_aftercare_objective_next_decision.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -227,6 +232,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_LISTENING_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_OBJECTIVE_NEXT_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_FINAL_REVIEW_HANDOFF_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_FINAL_REVIEW_HANDOFF_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_FINAL_REVIEW_HANDOFF_2026-06-11.md
@@ -1,0 +1,92 @@
+# Music Transformer Solo Yield Interval Contour Final Review Handoff
+
+## Summary
+
+- boundary: `music_transformer_solo_yield_interval_contour_final_review_handoff`
+- candidate count: `8`
+- MIDI/WAV count: `8` / `8`
+- technical WAV validation: `true`
+- objective residual label count: `0`
+- chord-tone ratio min/avg: `0.5000` / `0.5331`
+- note count min/max: `30` / `34`
+- max gap seconds: `0.6048`
+- max interval: `7`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- selected next target: `manual_listening_review_pending`
+- next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
+- musical quality claimed: `false`
+
+## Candidate Files
+
+- candidate `1` / `minor_backdoor`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/midi/candidate_01_minor_backdoor_interval_contour_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/audio/candidate_01_minor_backdoor_interval_contour_aftercare.wav`
+  - note count: `33`
+  - chord-tone ratio: `0.5152`
+  - max gap seconds: `0.6048`
+  - max interval: `7`
+  - residual labels: `none`
+- candidate `2` / `minor_backdoor`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/midi/candidate_02_minor_backdoor_interval_contour_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/audio/candidate_02_minor_backdoor_interval_contour_aftercare.wav`
+  - note count: `34`
+  - chord-tone ratio: `0.5000`
+  - max gap seconds: `0.4839`
+  - max interval: `7`
+  - residual labels: `none`
+- candidate `3` / `major_ii_v_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/midi/candidate_03_major_ii_v_turnaround_interval_contour_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/audio/candidate_03_major_ii_v_turnaround_interval_contour_aftercare.wav`
+  - note count: `32`
+  - chord-tone ratio: `0.5000`
+  - max gap seconds: `0.4839`
+  - max interval: `7`
+  - residual labels: `none`
+- candidate `4` / `major_ii_v_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/midi/candidate_04_major_ii_v_turnaround_interval_contour_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/audio/candidate_04_major_ii_v_turnaround_interval_contour_aftercare.wav`
+  - note count: `32`
+  - chord-tone ratio: `0.5000`
+  - max gap seconds: `0.6048`
+  - max interval: `7`
+  - residual labels: `none`
+- candidate `5` / `dominant_cycle`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/midi/candidate_05_dominant_cycle_interval_contour_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/audio/candidate_05_dominant_cycle_interval_contour_aftercare.wav`
+  - note count: `30`
+  - chord-tone ratio: `0.5667`
+  - max gap seconds: `0.6048`
+  - max interval: `7`
+  - residual labels: `none`
+- candidate `6` / `dominant_cycle`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/midi/candidate_06_dominant_cycle_interval_contour_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/audio/candidate_06_dominant_cycle_interval_contour_aftercare.wav`
+  - note count: `30`
+  - chord-tone ratio: `0.6333`
+  - max gap seconds: `0.4839`
+  - max interval: `7`
+  - residual labels: `none`
+- candidate `7` / `rhythm_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/midi/candidate_07_rhythm_turnaround_interval_contour_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/audio/candidate_07_rhythm_turnaround_interval_contour_aftercare.wav`
+  - note count: `30`
+  - chord-tone ratio: `0.5333`
+  - max gap seconds: `0.6048`
+  - max interval: `7`
+  - residual labels: `none`
+- candidate `8` / `rhythm_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/midi/candidate_08_rhythm_turnaround_interval_contour_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/audio/candidate_08_rhythm_turnaround_interval_contour_aftercare.wav`
+  - note count: `31`
+  - chord-tone ratio: `0.5161`
+  - max gap seconds: `0.6048`
+  - max interval: `7`
+  - residual labels: `none`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/build_music_transformer_solo_yield_interval_contour_final_review_handoff.py
+++ b/scripts/build_music_transformer_solo_yield_interval_contour_final_review_handoff.py
@@ -1,0 +1,446 @@
+"""Build final review handoff for interval-contour-aftercare solo candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.build_music_transformer_solo_yield_interval_contour_aftercare_listening_package import (  # noqa: E402
+    INPUT_SCHEMA_VERSION,
+    SCHEMA_VERSION as LISTENING_PACKAGE_SCHEMA_VERSION,
+)
+from scripts.decide_music_transformer_solo_yield_interval_contour_aftercare_objective_next import (  # noqa: E402
+    SCHEMA_VERSION as OBJECTIVE_DECISION_SCHEMA_VERSION,
+)
+from scripts.render_music_transformer_solo_yield_interval_contour_aftercare_audio import (  # noqa: E402
+    SCHEMA_VERSION as AUDIO_PACKAGE_SCHEMA_VERSION,
+)
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_interval_contour_final_review_handoff_v1"
+BOUNDARY = "music_transformer_solo_yield_interval_contour_final_review_handoff"
+NEXT_BOUNDARY = "music_transformer_solo_yield_interval_contour_aftercare_listening_review"
+
+
+class SoloYieldIntervalContourFinalReviewHandoffError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldIntervalContourFinalReviewHandoffError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_no_quality_claim(report: dict[str, Any], *, label: str) -> None:
+    readiness = _dict(report.get("readiness"))
+    claimed = [
+        key
+        for key in (
+            "audio_rendered_quality_claimed",
+            "musical_quality_claimed",
+            "artist_style_claimed",
+            "production_ready_claimed",
+        )
+        if bool(readiness.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldIntervalContourFinalReviewHandoffError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def _validate_listening_package(report: dict[str, Any]) -> list[dict[str, Any]]:
+    if str(report.get("schema_version") or "") != LISTENING_PACKAGE_SCHEMA_VERSION:
+        raise SoloYieldIntervalContourFinalReviewHandoffError("listening package schema required")
+    _require_no_quality_claim(report, label="listening_package")
+    readiness = _dict(report.get("readiness"))
+    if not bool(readiness.get("listening_package_ready", False)):
+        raise SoloYieldIntervalContourFinalReviewHandoffError("listening package ready flag required")
+    candidates = [_dict(row) for row in _list(report.get("candidates"))]
+    if not candidates:
+        raise SoloYieldIntervalContourFinalReviewHandoffError("listening candidates required")
+    if _int(readiness.get("candidate_midi_files_copied")) != len(candidates):
+        raise SoloYieldIntervalContourFinalReviewHandoffError("candidate MIDI count mismatch")
+    if _int(readiness.get("candidate_wav_files_copied")) != len(candidates):
+        raise SoloYieldIntervalContourFinalReviewHandoffError("candidate WAV count mismatch")
+    template = _dict(report.get("review_input_template"))
+    if str(template.get("schema_version") or "") != INPUT_SCHEMA_VERSION:
+        raise SoloYieldIntervalContourFinalReviewHandoffError("review input template schema required")
+    if str(template.get("review_status") or "") != "pending":
+        raise SoloYieldIntervalContourFinalReviewHandoffError("pending review input template required")
+    return candidates
+
+
+def _validate_audio_package(report: dict[str, Any], *, expected_count: int) -> list[dict[str, Any]]:
+    if str(report.get("schema_version") or "") != AUDIO_PACKAGE_SCHEMA_VERSION:
+        raise SoloYieldIntervalContourFinalReviewHandoffError("audio package schema required")
+    _require_no_quality_claim(report, label="audio_package")
+    aggregate = _dict(report.get("aggregate"))
+    if not bool(aggregate.get("technical_wav_validation", False)):
+        raise SoloYieldIntervalContourFinalReviewHandoffError("technical WAV validation required")
+    if _int(aggregate.get("rendered_wav_count")) < int(expected_count):
+        raise SoloYieldIntervalContourFinalReviewHandoffError("rendered WAV count below candidate count")
+    return [_dict(row) for row in _list(report.get("rendered_audio_files"))]
+
+
+def _validate_objective_decision(report: dict[str, Any], *, expected_count: int) -> list[dict[str, Any]]:
+    if str(report.get("schema_version") or "") != OBJECTIVE_DECISION_SCHEMA_VERSION:
+        raise SoloYieldIntervalContourFinalReviewHandoffError("objective decision schema required")
+    _require_no_quality_claim(report, label="objective_decision")
+    aggregate = _dict(report.get("aggregate"))
+    if _int(aggregate.get("candidate_count")) != int(expected_count):
+        raise SoloYieldIntervalContourFinalReviewHandoffError("objective candidate count mismatch")
+    residual_keys = (
+        "final_landing_not_chord_tone_count",
+        "midi_low_chord_tone_ratio_count",
+        "dead_air_aftercare_count",
+        "weak_direction_change_count",
+        "low_note_count_for_4bar_count",
+        "wide_interval_review_count",
+    )
+    residual_total = sum(_int(aggregate.get(key)) for key in residual_keys)
+    if residual_total != 0:
+        raise SoloYieldIntervalContourFinalReviewHandoffError(
+            f"objective residual risk must be zero: {residual_total}"
+        )
+    decision = _dict(report.get("decision"))
+    if str(decision.get("selected_next_target") or "") != "listening_review_required":
+        raise SoloYieldIntervalContourFinalReviewHandoffError("listening review decision required")
+    return [_dict(row) for row in _list(report.get("candidate_residuals"))]
+
+
+def _path_exists(path_value: Any) -> bool:
+    path = Path(str(path_value or ""))
+    return bool(str(path)) and path.exists()
+
+
+def build_candidate_handoff(
+    candidates: list[dict[str, Any]],
+    audio_rows: list[dict[str, Any]],
+    objective_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    audio_by_index = {_int(row.get("review_index")): row for row in audio_rows}
+    objective_by_index = {_int(row.get("review_index")): row for row in objective_rows}
+    handoff_rows: list[dict[str, Any]] = []
+    for row in candidates:
+        review_index = _int(row.get("review_index"))
+        objective = objective_by_index.get(review_index)
+        audio = audio_by_index.get(review_index)
+        if objective is None:
+            raise SoloYieldIntervalContourFinalReviewHandoffError(
+                f"objective residual row missing: {review_index}"
+            )
+        if audio is None:
+            raise SoloYieldIntervalContourFinalReviewHandoffError(
+                f"audio row missing: {review_index}"
+            )
+        review_midi_path = str(row.get("review_midi_path") or "")
+        review_wav_path = str(row.get("review_wav_path") or "")
+        if not _path_exists(review_midi_path):
+            raise SoloYieldIntervalContourFinalReviewHandoffError(
+                f"review MIDI missing: {review_midi_path}"
+            )
+        if not _path_exists(review_wav_path):
+            raise SoloYieldIntervalContourFinalReviewHandoffError(
+                f"review WAV missing: {review_wav_path}"
+            )
+        profile = _dict(objective.get("after_profile"))
+        residual_labels = [str(label) for label in _list(objective.get("residual_labels"))]
+        if residual_labels:
+            raise SoloYieldIntervalContourFinalReviewHandoffError(
+                f"unexpected residual labels for candidate {review_index}: {residual_labels}"
+            )
+        wav_file = _dict(row.get("review_wav_file"))
+        handoff_rows.append(
+            {
+                "review_index": review_index,
+                "case_label": str(row.get("case_label") or ""),
+                "review_midi_path": review_midi_path,
+                "review_wav_path": review_wav_path,
+                "review_midi_sha256": str(row.get("review_midi_sha256") or ""),
+                "review_wav_sha256": str(wav_file.get("sha256") or ""),
+                "duration_seconds": _float(wav_file.get("duration_seconds")),
+                "sample_rate": _int(wav_file.get("sample_rate")),
+                "objective_profile": {
+                    "midi_note_count": _int(profile.get("midi_note_count")),
+                    "midi_chord_tone_ratio": _float(profile.get("midi_chord_tone_ratio")),
+                    "midi_max_gap_seconds": _float(profile.get("midi_max_gap_seconds")),
+                    "midi_direction_change_ratio": _float(
+                        profile.get("midi_direction_change_ratio")
+                    ),
+                    "midi_max_abs_interval": _int(profile.get("midi_max_abs_interval")),
+                    "final_landing_chord": str(profile.get("final_landing_chord") or ""),
+                    "final_landing_is_chord_tone": bool(
+                        profile.get("final_landing_is_chord_tone", False)
+                    ),
+                },
+                "residual_labels": residual_labels,
+            }
+        )
+    return handoff_rows
+
+
+def build_handoff_package(
+    listening_package: dict[str, Any],
+    audio_package: dict[str, Any],
+    objective_decision: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    candidates = _validate_listening_package(listening_package)
+    audio_rows = _validate_audio_package(audio_package, expected_count=len(candidates))
+    objective_rows = _validate_objective_decision(objective_decision, expected_count=len(candidates))
+    handoff_rows = build_candidate_handoff(candidates, audio_rows, objective_rows)
+    objective_aggregate = _dict(objective_decision.get("aggregate"))
+    audio_aggregate = _dict(audio_package.get("aggregate"))
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_reports": {
+            "listening_package": {
+                "schema_version": listening_package.get("schema_version"),
+                "output_dir": listening_package.get("output_dir"),
+                "candidate_count": _int(listening_package.get("candidate_count")),
+            },
+            "audio_package": {
+                "schema_version": audio_package.get("schema_version"),
+                "output_dir": audio_package.get("output_dir"),
+                "rendered_wav_count": _int(audio_aggregate.get("rendered_wav_count")),
+                "technical_wav_validation": bool(
+                    audio_aggregate.get("technical_wav_validation", False)
+                ),
+            },
+            "objective_decision": {
+                "schema_version": objective_decision.get("schema_version"),
+                "output_dir": objective_decision.get("output_dir"),
+                "selected_next_target": _dict(objective_decision.get("decision")).get(
+                    "selected_next_target"
+                ),
+            },
+        },
+        "candidate_handoff": handoff_rows,
+        "aggregate": {
+            "candidate_count": len(handoff_rows),
+            "midi_count": len(handoff_rows),
+            "wav_count": len(handoff_rows),
+            "technical_wav_validation": bool(audio_aggregate.get("technical_wav_validation", False)),
+            "objective_residual_label_count": sum(
+                len(_list(row.get("residual_labels"))) for row in handoff_rows
+            ),
+            "midi_chord_tone_ratio_min": _float(
+                objective_aggregate.get("midi_chord_tone_ratio_min")
+            ),
+            "midi_chord_tone_ratio_avg": _float(
+                objective_aggregate.get("midi_chord_tone_ratio_avg")
+            ),
+            "midi_note_count_min": _int(objective_aggregate.get("midi_note_count_min")),
+            "midi_note_count_max": _int(objective_aggregate.get("midi_note_count_max")),
+            "midi_max_gap_seconds_max": _float(
+                objective_aggregate.get("midi_max_gap_seconds_max")
+            ),
+            "midi_max_abs_interval_max": _int(
+                objective_aggregate.get("midi_max_abs_interval_max")
+            ),
+        },
+        "readiness": {
+            "final_review_handoff_ready": bool(handoff_rows),
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "selected_next_target": "manual_listening_review_pending",
+            "next_boundary": NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+            "reason": "latest MIDI/WAV review candidates are packaged; listening preference input remains pending",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "artist_level_long_solo_generation",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "interval_contour_final_review_handoff.json", report)
+    write_json(
+        output_dir / "interval_contour_final_review_handoff_summary.json",
+        validate_report(report, require_no_quality_claim=True),
+    )
+    write_text(output_dir / "interval_contour_final_review_handoff.md", markdown_report(report))
+    return report
+
+
+def validate_report(report: dict[str, Any], *, require_no_quality_claim: bool) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldIntervalContourFinalReviewHandoffError("schema version mismatch")
+    readiness = _dict(report.get("readiness"))
+    if require_no_quality_claim:
+        _require_no_quality_claim(report, label="handoff")
+    aggregate = _dict(report.get("aggregate"))
+    decision = _dict(report.get("decision"))
+    return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "boundary": str(report.get("boundary") or ""),
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "midi_count": _int(aggregate.get("midi_count")),
+        "wav_count": _int(aggregate.get("wav_count")),
+        "technical_wav_validation": bool(aggregate.get("technical_wav_validation", False)),
+        "objective_residual_label_count": _int(aggregate.get("objective_residual_label_count")),
+        "validated_listening_input_present": bool(
+            readiness.get("validated_listening_input_present", True)
+        ),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "selected_next_target": str(decision.get("selected_next_target") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Music Transformer Solo Yield Interval Contour Final Review Handoff",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- MIDI/WAV count: `{aggregate['midi_count']}` / `{aggregate['wav_count']}`",
+        f"- technical WAV validation: `{_bool_token(aggregate['technical_wav_validation'])}`",
+        f"- objective residual label count: `{aggregate['objective_residual_label_count']}`",
+        f"- chord-tone ratio min/avg: `{float(aggregate['midi_chord_tone_ratio_min']):.4f}` / `{float(aggregate['midi_chord_tone_ratio_avg']):.4f}`",
+        f"- note count min/max: `{aggregate['midi_note_count_min']}` / `{aggregate['midi_note_count_max']}`",
+        f"- max gap seconds: `{float(aggregate['midi_max_gap_seconds_max']):.4f}`",
+        f"- max interval: `{aggregate['midi_max_abs_interval_max']}`",
+        f"- validated listening input present: `{_bool_token(readiness['validated_listening_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(readiness['preference_fill_allowed'])}`",
+        f"- selected next target: `{decision['selected_next_target']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        "",
+        "## Candidate Files",
+        "",
+    ]
+    for row in report.get("candidate_handoff", []):
+        profile = row["objective_profile"]
+        lines.extend(
+            [
+                f"- candidate `{row['review_index']}` / `{row['case_label']}`",
+                f"  - MIDI: `{row['review_midi_path']}`",
+                f"  - WAV: `{row['review_wav_path']}`",
+                f"  - note count: `{profile['midi_note_count']}`",
+                f"  - chord-tone ratio: `{float(profile['midi_chord_tone_ratio']):.4f}`",
+                f"  - max gap seconds: `{float(profile['midi_max_gap_seconds']):.4f}`",
+                f"  - max interval: `{profile['midi_max_abs_interval']}`",
+                f"  - residual labels: `none`",
+            ]
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build interval contour final review handoff")
+    parser.add_argument(
+        "--listening_package_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/"
+            "solo_yield_interval_contour_aftercare_listening_review/"
+            "issue_1308_interval_contour_listening_package/listening_review_package.json"
+        ),
+    )
+    parser.add_argument(
+        "--audio_package_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_audio/"
+            "issue_1306_interval_contour_audio_package/interval_contour_aftercare_audio_package.json"
+        ),
+    )
+    parser.add_argument(
+        "--objective_decision_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/"
+            "solo_yield_interval_contour_aftercare_objective_next/"
+            "issue_1312_interval_contour_objective_next/"
+            "interval_contour_aftercare_objective_next_decision.json"
+        ),
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_handoff_package(
+        read_json(Path(args.listening_package_report)),
+        read_json(Path(args.audio_package_report)),
+        read_json(Path(args.objective_decision_report)),
+        output_dir=output_dir,
+    )
+    summary = validate_report(report, require_no_quality_claim=bool(args.require_no_quality_claim))
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_interval_contour_final_review_handoff.py
+++ b/tests/test_music_transformer_solo_yield_interval_contour_final_review_handoff.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_music_transformer_solo_yield_interval_contour_aftercare_listening_package import (
+    INPUT_SCHEMA_VERSION,
+    SCHEMA_VERSION as LISTENING_PACKAGE_SCHEMA_VERSION,
+)
+from scripts.build_music_transformer_solo_yield_interval_contour_final_review_handoff import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SCHEMA_VERSION,
+    SoloYieldIntervalContourFinalReviewHandoffError,
+    build_handoff_package,
+    validate_report,
+)
+from scripts.decide_music_transformer_solo_yield_interval_contour_aftercare_objective_next import (
+    SCHEMA_VERSION as OBJECTIVE_DECISION_SCHEMA_VERSION,
+)
+from scripts.render_music_transformer_solo_yield_interval_contour_aftercare_audio import (
+    SCHEMA_VERSION as AUDIO_PACKAGE_SCHEMA_VERSION,
+)
+
+
+def touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"data")
+
+
+def wav_meta(path: Path) -> dict:
+    return {
+        "path": str(path),
+        "exists": True,
+        "size_bytes": 4,
+        "sha256": "abc123",
+        "channels": 2,
+        "sample_width_bytes": 2,
+        "sample_rate": 44100,
+        "frame_count": 44100,
+        "duration_seconds": 1.0,
+    }
+
+
+def listening_package(root: Path, *, quality_claim: bool = False) -> dict:
+    midi_path = root / "review" / "midi" / "candidate_01.mid"
+    wav_path = root / "review" / "audio" / "candidate_01.wav"
+    touch(midi_path)
+    touch(wav_path)
+    return {
+        "schema_version": LISTENING_PACKAGE_SCHEMA_VERSION,
+        "output_dir": str(root / "review"),
+        "candidate_count": 1,
+        "candidates": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "review_midi_path": str(midi_path),
+                "review_wav_path": str(wav_path),
+                "review_midi_sha256": "midi123",
+                "review_wav_file": wav_meta(wav_path),
+            }
+        ],
+        "review_input_template": {
+            "schema_version": INPUT_SCHEMA_VERSION,
+            "review_status": "pending",
+            "overall_decision": "pending",
+            "candidates": [{"review_index": 1, "decision": "pending"}],
+        },
+        "readiness": {
+            "listening_package_ready": True,
+            "candidate_midi_files_copied": 1,
+            "candidate_wav_files_copied": 1,
+            "review_input_template_written": True,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def audio_package(root: Path) -> dict:
+    midi_path = root / "source" / "candidate_01.mid"
+    wav_path = root / "source" / "candidate_01.wav"
+    touch(midi_path)
+    touch(wav_path)
+    return {
+        "schema_version": AUDIO_PACKAGE_SCHEMA_VERSION,
+        "output_dir": str(root / "source"),
+        "rendered_audio_files": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "repaired_midi_path": str(midi_path),
+                "wav_file": wav_meta(wav_path),
+            }
+        ],
+        "aggregate": {
+            "rendered_wav_count": 1,
+            "technical_wav_validation": True,
+        },
+        "readiness": {
+            "audio_package_completed": True,
+            "technical_wav_validation": True,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def objective_decision() -> dict:
+    return {
+        "schema_version": OBJECTIVE_DECISION_SCHEMA_VERSION,
+        "output_dir": "outputs/objective",
+        "candidate_residuals": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "after_profile": {
+                    "midi_note_count": 33,
+                    "midi_chord_tone_ratio": 0.52,
+                    "midi_max_gap_seconds": 0.60,
+                    "midi_direction_change_ratio": 0.58,
+                    "midi_max_abs_interval": 7,
+                    "final_landing_chord": "Ebmaj7",
+                    "final_landing_is_chord_tone": True,
+                },
+                "residual_labels": [],
+            }
+        ],
+        "aggregate": {
+            "candidate_count": 1,
+            "final_landing_not_chord_tone_count": 0,
+            "midi_low_chord_tone_ratio_count": 0,
+            "dead_air_aftercare_count": 0,
+            "weak_direction_change_count": 0,
+            "low_note_count_for_4bar_count": 0,
+            "wide_interval_review_count": 0,
+            "midi_chord_tone_ratio_min": 0.52,
+            "midi_chord_tone_ratio_avg": 0.52,
+            "midi_note_count_min": 33,
+            "midi_note_count_max": 33,
+            "midi_max_gap_seconds_max": 0.60,
+            "midi_max_abs_interval_max": 7,
+        },
+        "decision": {
+            "selected_next_target": "listening_review_required",
+            "next_boundary": "music_transformer_solo_yield_interval_contour_aftercare_listening_review",
+        },
+        "readiness": {
+            "objective_only_next_decision_completed": True,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldIntervalContourFinalReviewHandoffTest(unittest.TestCase):
+    def test_builds_final_handoff_for_ready_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_handoff_package(
+                listening_package(root),
+                audio_package(root),
+                objective_decision(),
+                output_dir=root / "out",
+            )
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["boundary"], BOUNDARY)
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["midi_count"], 1)
+        self.assertEqual(summary["wav_count"], 1)
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertEqual(summary["objective_residual_label_count"], 0)
+        self.assertFalse(summary["validated_listening_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertEqual(summary["selected_next_target"], "manual_listening_review_pending")
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertFalse(summary["musical_quality_claimed"])
+
+    def test_rejects_quality_claim_from_source_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(SoloYieldIntervalContourFinalReviewHandoffError):
+                build_handoff_package(
+                    listening_package(root, quality_claim=True),
+                    audio_package(root),
+                    objective_decision(),
+                    output_dir=root / "out",
+                )
+
+    def test_rejects_objective_residual_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            objective = objective_decision()
+            objective["candidate_residuals"][0]["residual_labels"] = ["wide_interval_review"]
+            with self.assertRaises(SoloYieldIntervalContourFinalReviewHandoffError):
+                build_handoff_package(
+                    listening_package(root),
+                    audio_package(root),
+                    objective,
+                    output_dir=root / "out",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- interval contour final review handoff package 추가
- 최신 MIDI/WAV 후보 8개와 objective decision 연결
- 후보별 path, objective metric, residual label manifest 작성
- quality claim false guard 유지
- README 최신 결과 파일 갱신

## Context

- #1312 objective-only decision 결과
- candidate count: `8`
- MIDI low chord-tone ratio count: `0`
- low note count for 4bar: `0`
- wide interval review count: `0`
- dead-air aftercare count: `0`
- weak direction-change count: `0`
- final landing not chord-tone count: `0`
- selected next target: `listening_review_required`
- validated listening input: `false`

## Scope

- listening package, audio package, objective decision schema 검증
- 후보별 review MIDI/WAV 경로 존재 검증
- objective residual label 0 검증
- handoff JSON/MD 생성
- README evidence 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_music_transformer_solo_yield_interval_contour_final_review_handoff.py`
- `.venv/bin/python scripts/build_music_transformer_solo_yield_interval_contour_final_review_handoff.py --run_id issue_1314_interval_contour_final_handoff --doc_path docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_FINAL_REVIEW_HANDOFF_2026-06-11.md --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- candidate count: `8`
- MIDI count: `8`
- WAV count: `8`
- technical WAV validation: `true`
- objective residual label count: `0`
- validated listening input present: `false`
- preference fill allowed: `false`
- selected next target: `manual_listening_review_pending`
- next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
- musical quality claim: `false`

## Risk

- 청취 선호 입력 미포함
- objective metric 기준 residual 0과 실제 음악적 품질은 별도 검토 대상
- 현재 handoff는 파일 manifest이며 raw artifact 업로드는 포함하지 않음

## Follow-up

- manual listening review or additional repeatability audit

Closes #1314