### PR TITLE
Stage B MIDI-to-solo interval contour handoff reproducibility audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- interval contour final handoff: MIDI `8`, WAV `8`, objective residual labels `0`
+- interval contour handoff audit: missing files `0`, checksum mismatch `0`, residual labels `0`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -162,6 +162,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
 - interval contour final review handoff: MIDI `8`, WAV `8`, objective residual labels `0`, preference fill `false`
 - next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
+- interval contour handoff reproducibility audit: missing MIDI/WAV `0 / 0`, checksum mismatch `0 / 0`, reproducible handoff `true`
+- next boundary: `music_transformer_solo_yield_sampling_repeatability_audit`
 
 ## 결과 파일
 
@@ -169,6 +171,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit/issue_1316_interval_contour_handoff_audit/interval_contour_handoff_reproducibility_audit.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit/issue_1316_interval_contour_handoff_audit/interval_contour_handoff_reproducibility_audit.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`
@@ -188,6 +192,7 @@ Report:
 - `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1254_4bar_repaired_objective_next_decision/objective_next_decision.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_objective_next/issue_1312_interval_contour_objective_next/interval_contour_aftercare_objective_next_decision.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit/issue_1316_interval_contour_handoff_audit/interval_contour_handoff_reproducibility_audit.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -233,6 +238,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_OBJECTIVE_NEXT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_FINAL_REVIEW_HANDOFF_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md
@@ -1,0 +1,65 @@
+# Music Transformer Solo Yield Interval Contour Handoff Reproducibility Audit
+
+## Summary
+
+- boundary: `music_transformer_solo_yield_interval_contour_handoff_reproducibility_audit`
+- candidate count: `8`
+- missing MIDI/WAV: `0` / `0`
+- checksum mismatch MIDI/WAV: `0` / `0`
+- objective residual label count: `0`
+- duration range seconds: `10.7247` - `10.7392`
+- sample rates: `44100`
+- reproducible handoff: `true`
+- selected next target: `sampling_repeatability_audit`
+- next boundary: `music_transformer_solo_yield_sampling_repeatability_audit`
+- musical quality claimed: `false`
+
+## Candidate File Audit
+
+- candidate `1` / `minor_backdoor`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7392`
+  - residual label count: `0`
+- candidate `2` / `minor_backdoor`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7378`
+  - residual label count: `0`
+- candidate `3` / `major_ii_v_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7349`
+  - residual label count: `0`
+- candidate `4` / `major_ii_v_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7378`
+  - residual label count: `0`
+- candidate `5` / `dominant_cycle`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7378`
+  - residual label count: `0`
+- candidate `6` / `dominant_cycle`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7247`
+  - residual label count: `0`
+- candidate `7` / `rhythm_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7349`
+  - residual label count: `0`
+- candidate `8` / `rhythm_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7378`
+  - residual label count: `0`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/audit_music_transformer_solo_yield_interval_contour_handoff_reproducibility.py
+++ b/scripts/audit_music_transformer_solo_yield_interval_contour_handoff_reproducibility.py
@@ -1,0 +1,350 @@
+"""Audit reproducibility of the interval-contour final review handoff package."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.build_music_transformer_solo_yield_interval_contour_final_review_handoff import (  # noqa: E402
+    SCHEMA_VERSION as HANDOFF_SCHEMA_VERSION,
+    validate_report as validate_handoff_report,
+)
+from scripts.render_stage_b_midi_to_solo_candidate_audio import sha256_file, wav_meta  # noqa: E402
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_interval_contour_handoff_reproducibility_audit_v1"
+BOUNDARY = "music_transformer_solo_yield_interval_contour_handoff_reproducibility_audit"
+NEXT_BOUNDARY = "music_transformer_solo_yield_sampling_repeatability_audit"
+
+
+class SoloYieldIntervalContourHandoffReproducibilityAuditError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_no_quality_claim(report: dict[str, Any]) -> None:
+    readiness = _dict(report.get("readiness"))
+    claimed = [
+        key
+        for key in (
+            "audio_rendered_quality_claimed",
+            "musical_quality_claimed",
+            "artist_style_claimed",
+            "production_ready_claimed",
+        )
+        if bool(readiness.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError(
+            f"unexpected quality claim: {claimed}"
+        )
+
+
+def validate_source_handoff(
+    handoff_report: dict[str, Any],
+    *,
+    expected_candidate_count: int,
+    expected_residual_label_count: int,
+) -> dict[str, Any]:
+    if str(handoff_report.get("schema_version") or "") != HANDOFF_SCHEMA_VERSION:
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError("handoff schema required")
+    summary = validate_handoff_report(handoff_report, require_no_quality_claim=True)
+    if _int(summary.get("candidate_count")) != int(expected_candidate_count):
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError("candidate count mismatch")
+    if _int(summary.get("midi_count")) != int(expected_candidate_count):
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError("MIDI count mismatch")
+    if _int(summary.get("wav_count")) != int(expected_candidate_count):
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError("WAV count mismatch")
+    if _int(summary.get("objective_residual_label_count")) != int(expected_residual_label_count):
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError(
+            "objective residual label count mismatch"
+        )
+    if not bool(summary.get("technical_wav_validation", False)):
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError("technical WAV validation required")
+    return summary
+
+
+def audit_candidate_files(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    audit_rows: list[dict[str, Any]] = []
+    for row in rows:
+        review_index = _int(row.get("review_index"))
+        midi_path = Path(str(row.get("review_midi_path") or ""))
+        wav_path = Path(str(row.get("review_wav_path") or ""))
+        midi_exists = midi_path.exists()
+        wav_exists = wav_path.exists()
+        expected_midi_sha = str(row.get("review_midi_sha256") or "")
+        expected_wav_sha = str(row.get("review_wav_sha256") or "")
+        actual_midi_sha = sha256_file(midi_path) if midi_exists else ""
+        actual_wav_meta = wav_meta(wav_path) if wav_exists else {}
+        actual_wav_sha = str(actual_wav_meta.get("sha256") or "")
+        audit_rows.append(
+            {
+                "review_index": review_index,
+                "case_label": str(row.get("case_label") or ""),
+                "midi_path": str(midi_path),
+                "wav_path": str(wav_path),
+                "midi_exists": midi_exists,
+                "wav_exists": wav_exists,
+                "midi_sha256_matches": bool(expected_midi_sha)
+                and expected_midi_sha == actual_midi_sha,
+                "wav_sha256_matches": bool(expected_wav_sha) and expected_wav_sha == actual_wav_sha,
+                "sample_rate": _int(actual_wav_meta.get("sample_rate")),
+                "duration_seconds": _float(actual_wav_meta.get("duration_seconds")),
+                "residual_label_count": len(_list(row.get("residual_labels"))),
+            }
+        )
+    return audit_rows
+
+
+def aggregate_candidate_audit(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    missing_midi = sum(1 for row in rows if not bool(row.get("midi_exists", False)))
+    missing_wav = sum(1 for row in rows if not bool(row.get("wav_exists", False)))
+    midi_mismatch = sum(1 for row in rows if not bool(row.get("midi_sha256_matches", False)))
+    wav_mismatch = sum(1 for row in rows if not bool(row.get("wav_sha256_matches", False)))
+    residual_labels = sum(_int(row.get("residual_label_count")) for row in rows)
+    durations = [_float(row.get("duration_seconds")) for row in rows]
+    sample_rates = sorted({_int(row.get("sample_rate")) for row in rows})
+    return {
+        "candidate_count": len(rows),
+        "missing_midi_count": missing_midi,
+        "missing_wav_count": missing_wav,
+        "midi_checksum_mismatch_count": midi_mismatch,
+        "wav_checksum_mismatch_count": wav_mismatch,
+        "objective_residual_label_count": residual_labels,
+        "duration_min_seconds": min(durations, default=0.0),
+        "duration_max_seconds": max(durations, default=0.0),
+        "sample_rates": sample_rates,
+        "reproducible_handoff": (
+            bool(rows)
+            and missing_midi == 0
+            and missing_wav == 0
+            and midi_mismatch == 0
+            and wav_mismatch == 0
+            and residual_labels == 0
+        ),
+    }
+
+
+def build_reproducibility_audit(
+    handoff_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    expected_candidate_count: int,
+    expected_residual_label_count: int,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source_summary = validate_source_handoff(
+        handoff_report,
+        expected_candidate_count=int(expected_candidate_count),
+        expected_residual_label_count=int(expected_residual_label_count),
+    )
+    _require_no_quality_claim(handoff_report)
+    candidate_rows = [_dict(row) for row in _list(handoff_report.get("candidate_handoff"))]
+    if len(candidate_rows) != int(expected_candidate_count):
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError("handoff row count mismatch")
+    candidate_file_audit = audit_candidate_files(candidate_rows)
+    aggregate = aggregate_candidate_audit(candidate_file_audit)
+    if not bool(aggregate.get("reproducible_handoff", False)):
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError(
+            f"handoff reproducibility audit failed: {aggregate}"
+        )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_handoff": {
+            "schema_version": handoff_report.get("schema_version"),
+            "output_dir": handoff_report.get("output_dir"),
+            "candidate_count": _int(source_summary.get("candidate_count")),
+            "midi_count": _int(source_summary.get("midi_count")),
+            "wav_count": _int(source_summary.get("wav_count")),
+            "objective_residual_label_count": _int(
+                source_summary.get("objective_residual_label_count")
+            ),
+            "technical_wav_validation": bool(
+                source_summary.get("technical_wav_validation", False)
+            ),
+        },
+        "candidate_file_audit": candidate_file_audit,
+        "aggregate": aggregate,
+        "readiness": {
+            "reproducibility_audit_completed": True,
+            "reproducible_handoff": bool(aggregate.get("reproducible_handoff", False)),
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "selected_next_target": "sampling_repeatability_audit",
+            "next_boundary": NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+            "reason": "final handoff is reproducible; next objective-only check is broader sampling repeatability",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "artist_level_long_solo_generation",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "interval_contour_handoff_reproducibility_audit.json", report)
+    write_json(
+        output_dir / "interval_contour_handoff_reproducibility_audit_summary.json",
+        validate_report(report, require_no_quality_claim=True),
+    )
+    write_text(output_dir / "interval_contour_handoff_reproducibility_audit.md", markdown_report(report))
+    return report
+
+
+def validate_report(report: dict[str, Any], *, require_no_quality_claim: bool) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldIntervalContourHandoffReproducibilityAuditError("schema version mismatch")
+    readiness = _dict(report.get("readiness"))
+    if require_no_quality_claim:
+        _require_no_quality_claim(report)
+    aggregate = _dict(report.get("aggregate"))
+    decision = _dict(report.get("decision"))
+    return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "boundary": str(report.get("boundary") or ""),
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "missing_midi_count": _int(aggregate.get("missing_midi_count")),
+        "missing_wav_count": _int(aggregate.get("missing_wav_count")),
+        "midi_checksum_mismatch_count": _int(
+            aggregate.get("midi_checksum_mismatch_count")
+        ),
+        "wav_checksum_mismatch_count": _int(aggregate.get("wav_checksum_mismatch_count")),
+        "objective_residual_label_count": _int(aggregate.get("objective_residual_label_count")),
+        "reproducible_handoff": bool(readiness.get("reproducible_handoff", False)),
+        "selected_next_target": str(decision.get("selected_next_target") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Music Transformer Solo Yield Interval Contour Handoff Reproducibility Audit",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- missing MIDI/WAV: `{aggregate['missing_midi_count']}` / `{aggregate['missing_wav_count']}`",
+        f"- checksum mismatch MIDI/WAV: `{aggregate['midi_checksum_mismatch_count']}` / `{aggregate['wav_checksum_mismatch_count']}`",
+        f"- objective residual label count: `{aggregate['objective_residual_label_count']}`",
+        f"- duration range seconds: `{float(aggregate['duration_min_seconds']):.4f}` - `{float(aggregate['duration_max_seconds']):.4f}`",
+        f"- sample rates: `{','.join(str(rate) for rate in aggregate['sample_rates'])}`",
+        f"- reproducible handoff: `{_bool_token(readiness['reproducible_handoff'])}`",
+        f"- selected next target: `{decision['selected_next_target']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        "",
+        "## Candidate File Audit",
+        "",
+    ]
+    for row in report.get("candidate_file_audit", []):
+        lines.extend(
+            [
+                f"- candidate `{row['review_index']}` / `{row['case_label']}`",
+                f"  - MIDI exists/checksum: `{_bool_token(row['midi_exists'])}` / `{_bool_token(row['midi_sha256_matches'])}`",
+                f"  - WAV exists/checksum: `{_bool_token(row['wav_exists'])}` / `{_bool_token(row['wav_sha256_matches'])}`",
+                f"  - duration seconds: `{float(row['duration_seconds']):.4f}`",
+                f"  - residual label count: `{row['residual_label_count']}`",
+            ]
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit interval contour final handoff reproducibility")
+    parser.add_argument(
+        "--handoff_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/"
+            "issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.json"
+        ),
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_count", type=int, default=8)
+    parser.add_argument("--expected_residual_label_count", type=int, default=0)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_reproducibility_audit(
+        read_json(Path(args.handoff_report)),
+        output_dir=output_dir,
+        expected_candidate_count=int(args.expected_candidate_count),
+        expected_residual_label_count=int(args.expected_residual_label_count),
+    )
+    summary = validate_report(report, require_no_quality_claim=bool(args.require_no_quality_claim))
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_interval_contour_handoff_reproducibility_audit.py
+++ b/tests/test_music_transformer_solo_yield_interval_contour_handoff_reproducibility_audit.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+
+from scripts.audit_music_transformer_solo_yield_interval_contour_handoff_reproducibility import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SCHEMA_VERSION,
+    SoloYieldIntervalContourHandoffReproducibilityAuditError,
+    build_reproducibility_audit,
+    validate_report,
+)
+from scripts.build_music_transformer_solo_yield_interval_contour_final_review_handoff import (
+    SCHEMA_VERSION as HANDOFF_SCHEMA_VERSION,
+)
+from scripts.render_stage_b_midi_to_solo_candidate_audio import sha256_file, wav_meta
+
+
+def write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(2)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(44100)
+        wav_file.writeframes(b"\x00\x00\x00\x00" * 441)
+
+
+def write_midi(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"MThd\x00\x00\x00\x06\x00\x01\x00\x01\x01\xe0")
+
+
+def handoff_report(root: Path, *, bad_midi_checksum: bool = False, residual_count: int = 0) -> dict:
+    midi_path = root / "candidate.mid"
+    wav_path = root / "candidate.wav"
+    write_midi(midi_path)
+    write_wav(wav_path)
+    return {
+        "schema_version": HANDOFF_SCHEMA_VERSION,
+        "output_dir": str(root),
+        "boundary": "music_transformer_solo_yield_interval_contour_final_review_handoff",
+        "candidate_handoff": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "review_midi_path": str(midi_path),
+                "review_wav_path": str(wav_path),
+                "review_midi_sha256": "bad" if bad_midi_checksum else sha256_file(midi_path),
+                "review_wav_sha256": str(wav_meta(wav_path)["sha256"]),
+                "duration_seconds": float(wav_meta(wav_path)["duration_seconds"]),
+                "sample_rate": 44100,
+                "objective_profile": {
+                    "midi_note_count": 33,
+                    "midi_chord_tone_ratio": 0.52,
+                    "midi_max_gap_seconds": 0.60,
+                    "midi_direction_change_ratio": 0.58,
+                    "midi_max_abs_interval": 7,
+                    "final_landing_chord": "Ebmaj7",
+                    "final_landing_is_chord_tone": True,
+                },
+                "residual_labels": ["wide_interval_review"] if residual_count else [],
+            }
+        ],
+        "aggregate": {
+            "candidate_count": 1,
+            "midi_count": 1,
+            "wav_count": 1,
+            "technical_wav_validation": True,
+            "objective_residual_label_count": residual_count,
+        },
+        "readiness": {
+            "final_review_handoff_ready": True,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "selected_next_target": "manual_listening_review_pending",
+            "next_boundary": "music_transformer_solo_yield_interval_contour_aftercare_listening_review",
+        },
+    }
+
+
+class MusicTransformerSoloYieldIntervalContourHandoffReproducibilityAuditTest(unittest.TestCase):
+    def test_builds_reproducibility_audit_for_matching_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_reproducibility_audit(
+                handoff_report(root),
+                output_dir=root / "out",
+                expected_candidate_count=1,
+                expected_residual_label_count=0,
+            )
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["boundary"], BOUNDARY)
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["missing_midi_count"], 0)
+        self.assertEqual(summary["missing_wav_count"], 0)
+        self.assertEqual(summary["midi_checksum_mismatch_count"], 0)
+        self.assertEqual(summary["wav_checksum_mismatch_count"], 0)
+        self.assertEqual(summary["objective_residual_label_count"], 0)
+        self.assertTrue(summary["reproducible_handoff"])
+        self.assertEqual(summary["selected_next_target"], "sampling_repeatability_audit")
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertFalse(summary["musical_quality_claimed"])
+
+    def test_rejects_checksum_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(SoloYieldIntervalContourHandoffReproducibilityAuditError):
+                build_reproducibility_audit(
+                    handoff_report(root, bad_midi_checksum=True),
+                    output_dir=root / "out",
+                    expected_candidate_count=1,
+                    expected_residual_label_count=0,
+                )
+
+    def test_rejects_residual_label_count(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(SoloYieldIntervalContourHandoffReproducibilityAuditError):
+                build_reproducibility_audit(
+                    handoff_report(root, residual_count=1),
+                    output_dir=root / "out",
+                    expected_candidate_count=1,
+                    expected_residual_label_count=0,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- interval contour final handoff reproducibility audit 추가
- 후보별 MIDI/WAV 파일 존재와 checksum 일치 검증
- objective residual label count 0 재검증
- next sampling repeatability boundary 기록
- README 최신 evidence 갱신

## Context

- #1314 final review handoff 결과
- candidate count: `8`
- MIDI count: `8`
- WAV count: `8`
- technical WAV validation: `true`
- objective residual label count: `0`
- validated listening input: `false`
- preference fill allowed: `false`

## Scope

- handoff schema와 summary metric 검증
- candidate MIDI/WAV path 존재 검증
- recorded checksum과 현재 파일 checksum 비교
- audit JSON/MD 생성
- README evidence 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_music_transformer_solo_yield_interval_contour_handoff_reproducibility_audit.py`
- `.venv/bin/python scripts/audit_music_transformer_solo_yield_interval_contour_handoff_reproducibility.py --run_id issue_1316_interval_contour_handoff_audit --doc_path docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- candidate count: `8`
- missing MIDI/WAV: `0 / 0`
- checksum mismatch MIDI/WAV: `0 / 0`
- objective residual label count: `0`
- reproducible handoff: `true`
- selected next target: `sampling_repeatability_audit`
- next boundary: `music_transformer_solo_yield_sampling_repeatability_audit`
- musical quality claim: `false`

## Risk

- 청취 선호 입력 미포함
- 실제 음악적 품질 판단 범위 제외
- sampling 확장 검증은 다음 작업 범위

## Follow-up

- sampling repeatability audit

Closes #1316