### PR TITLE
Stage B MIDI-to-solo sampling repeatability audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- interval contour handoff audit: missing files `0`, checksum mismatch `0`, residual labels `0`
+- sampling repeatability audit: grammar `12 / 12`, strict `8 / 12`, failing case `rhythm_turnaround`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -164,6 +164,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_interval_contour_aftercare_listening_review`
 - interval contour handoff reproducibility audit: missing MIDI/WAV `0 / 0`, checksum mismatch `0 / 0`, reproducible handoff `true`
 - next boundary: `music_transformer_solo_yield_sampling_repeatability_audit`
+- sampling repeatability audit: grammar `12 / 12`, strict `8 / 12`, min case strict rate `0.3333`
+- failing case: `rhythm_turnaround`, strict `1 / 3`
+- next boundary: `music_transformer_solo_yield_failure_case_review`
 
 ## 결과 파일
 
@@ -173,6 +176,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit/issue_1316_interval_contour_handoff_audit/interval_contour_handoff_reproducibility_audit.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit/issue_1316_interval_contour_handoff_audit/interval_contour_handoff_reproducibility_audit.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`
@@ -193,6 +198,7 @@ Report:
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_objective_next/issue_1312_interval_contour_objective_next/interval_contour_aftercare_objective_next_decision.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit/issue_1316_interval_contour_handoff_audit/interval_contour_handoff_reproducibility_audit.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -239,6 +245,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_AFTERCARE_OBJECTIVE_NEXT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_FINAL_REVIEW_HANDOFF_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md
@@ -1,0 +1,44 @@
+# Stage B MIDI-to-Solo Chord Progression Yield Sweep
+
+## Summary
+
+- checkpoint generation used: `true`
+- constrained decoding used: `true`
+- case count: `4`
+- sample count: `12`
+- duration mode: `fill`
+- valid yield: `8` / `12`
+- strict yield: `8` / `12`
+- grammar yield: `12` / `12`
+- strict yield rate: `0.6667`
+- min case strict yield rate: `0.3333`
+- selected MIDI candidates: `0`
+- rendered WAV files: `0`
+- total yield floor passed: `false`
+- all case yield floor passed: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_failure_case_review`
+
+## Cases
+
+| case | chords | seed | strict | valid | grammar | strict rate | avg notes | avg dead air | package |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 1600 | 3/3 | 3/3 | 3/3 | 1.0000 | 26.00 | 0.6946 | `none` |
+| `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 1617 | 2/3 | 2/3 | 3/3 | 0.6667 | 28.50 | 0.7639 | `none` |
+| `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 1634 | 2/3 | 2/3 | 3/3 | 0.6667 | 28.50 | 0.6373 | `none` |
+| `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 1651 | 1/3 | 1/3 | 3/3 | 0.3333 | 26.00 | 0.7200 | `none` |
+
+## Failing Cases
+
+- `rhythm_turnaround`: strict `1` / `3`, rate `0.3333`
+
+## WAV Files
+
+- `none`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary

- sampling repeatability audit 결과 기록
- 4개 chord progression x 3 samples, 4bar/fill 조건 실행
- grammar/strict yield와 failing case 기록
- README 최신 evidence 갱신

## Context

- #1316 handoff reproducibility audit 결과
- candidate count: `8`
- missing MIDI/WAV: `0 / 0`
- checksum mismatch MIDI/WAV: `0 / 0`
- reproducible handoff: `true`
- selected next target: `sampling_repeatability_audit`

## Scope

- 기존 solo yield sweep 실행
- package 생략, objective yield만 기록
- failing case 분리
- quality claim false 유지

## Validation

- `.venv/bin/python scripts/run_music_transformer_solo_yield_sweep.py --run_id issue_1318_sampling_repeatability_audit --doc_path docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md --sample_count 3 --bars 4 --duration_mode fill --note_groups_per_bar 8 --seed_start 1600 --seed_stride 17 --skip_package --min_cases 4 --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- case count: `4`
- sample count: `12`
- grammar gate sample count: `12`
- valid sample count: `8`
- strict valid sample count: `8`
- strict yield rate: `0.6667`
- min case strict yield rate: `0.3333`
- total yield floor passed: `false`
- all case yield floor passed: `false`
- failing case: `rhythm_turnaround`, strict `1 / 3`
- next boundary: `music_transformer_solo_yield_failure_case_review`
- musical quality claim: `false`

## Risk

- package/WAV render 생략
- 청취 선호 입력 미포함
- failing case review와 repair target decision은 다음 작업 범위

## Follow-up

- sampling failure case review

Closes #1318