### PR TITLE
Stage B MIDI-to-solo sampling failure case review

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- sampling repeatability audit: grammar `12 / 12`, strict `8 / 12`, failing case `rhythm_turnaround`
+- sampling failure review: failing case `1`, dead-air fail `2`, next `dead_air_repair_sweep`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -167,6 +167,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - sampling repeatability audit: grammar `12 / 12`, strict `8 / 12`, min case strict rate `0.3333`
 - failing case: `rhythm_turnaround`, strict `1 / 3`
 - next boundary: `music_transformer_solo_yield_failure_case_review`
+- sampling failure case review: failing case `1`, invalid samples `2`, dead-air fail `2`
+- excluded primary causes: grammar `1`, collapse `1`
+- next boundary: `music_transformer_solo_yield_dead_air_repair_sweep`
 
 ## 결과 파일
 
@@ -178,6 +181,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit/issue_1316_interval_contour_handoff_audit/interval_contour_handoff_reproducibility_audit.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`
@@ -199,6 +204,7 @@ Report:
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_final_handoff/issue_1314_interval_contour_final_handoff/interval_contour_final_review_handoff.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit/issue_1316_interval_contour_handoff_audit/interval_contour_handoff_reproducibility_audit.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -246,6 +252,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_FINAL_REVIEW_HANDOFF_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_FAILURE_CASE_REVIEW_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_FAILURE_CASE_REVIEW_2026-06-11.md
@@ -1,0 +1,40 @@
+# Stage B MIDI-to-Solo Yield Failure Case Review
+
+## Summary
+
+- source strict yield: `8` / `12`
+- min case strict yield rate: `0.3333`
+- failing case count: `1`
+- reviewed invalid samples: `2`
+- dead-air failure count: `2`
+- grammar primary cause excluded count: `1`
+- collapse primary cause excluded count: `1`
+- selected repair target: `duration_fill_or_overlap_aftercare`
+- next boundary: `music_transformer_solo_yield_dead_air_repair_sweep`
+- musical quality claimed: `false`
+
+## Case Reviews
+
+### rhythm_turnaround
+
+- chords: `Bbmaj7,G7,Cm7,F7`
+- strict: `1` / `3`
+- dominant failure: `dead_air_threshold_miss`
+- repair target: `duration_fill_or_overlap_aftercare`
+- invalid avg dead-air: `0.8181`
+- strict avg dead-air: `0.7200`
+- invalid avg postprocess removal: `0.1094`
+- strict avg postprocess removal: `0.1875`
+
+| sample | strict | failure | notes | dead air | removed | removal ratio | duration common | MIDI |
+|---:|---|---|---:|---:|---:|---:|---:|---|
+| 1 | `false` | `dead-air ratio too high: 0.821 >= 0.800` | 29 | 0.8214 | 3 | 0.0938 | 0.7188 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/probes/04_rhythm_turnaround_seed_1651/samples/stage_b_sample_1.mid` |
+| 2 | `false` | `dead-air ratio too high: 0.815 >= 0.800` | 28 | 0.8148 | 4 | 0.1250 | 0.8125 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/probes/04_rhythm_turnaround_seed_1651/samples/stage_b_sample_2.mid` |
+| 3 | `true` | `none` | 26 | 0.7200 | 6 | 0.1875 | 0.6250 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/probes/04_rhythm_turnaround_seed_1651/samples/stage_b_sample_3.mid` |
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `repair_effectiveness`
+- `artist_level_long_solo_generation`


### PR DESCRIPTION
## Summary

- sampling failure case review 결과 기록
- rhythm_turnaround strict failure 원인 분리
- grammar/collapse primary cause 후보 제외
- next repair target 기록
- README 최신 evidence 갱신

## Context

- #1318 sampling repeatability audit 결과
- grammar gate: `12 / 12`
- strict valid: `8 / 12`
- min case strict rate: `0.3333`
- failing case: `rhythm_turnaround`, strict `1 / 3`
- next boundary: `music_transformer_solo_yield_failure_case_review`

## Scope

- existing failure review script 실행
- failing samples failure reason 집계
- dead-air threshold miss 여부 확인
- grammar/collapse primary cause 제외 여부 기록
- README evidence 갱신

## Validation

- `.venv/bin/python scripts/review_music_transformer_solo_yield_failure_cases.py --sweep_report outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.json --run_id issue_1320_sampling_failure_review --doc_path docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_FAILURE_CASE_REVIEW_2026-06-11.md --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- failing case count: `1`
- reviewed invalid sample count: `2`
- dead-air fail count: `2`
- grammar primary cause excluded count: `1`
- collapse primary cause excluded count: `1`
- selected repair target: `duration_fill_or_overlap_aftercare`
- next boundary: `music_transformer_solo_yield_dead_air_repair_sweep`
- critical user input required: `false`
- musical quality claim: `false`

## Risk

- repair effectiveness 미검증
- 청취 선호 입력 미포함
- 다음 repair sweep에서 strict yield 회복 여부 검증 필요

## Follow-up

- sampling dead-air repair sweep

Closes #1320