### PR TITLE
Stage B MIDI-to-solo sampling dead-air repair sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- sampling failure review: failing case `1`, dead-air fail `2`, next `dead_air_repair_sweep`
+- sampling dead-air repair: `rhythm_turnaround` strict `1 / 3 -> 3 / 3`, dead-air fail `2 -> 0`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -170,6 +170,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - sampling failure case review: failing case `1`, invalid samples `2`, dead-air fail `2`
 - excluded primary causes: grammar `1`, collapse `1`
 - next boundary: `music_transformer_solo_yield_dead_air_repair_sweep`
+- sampling dead-air repair sweep: selected `fill_n9`, strict `1 / 3 -> 3 / 3`, dead-air fail `2 -> 0`, rendered WAV `2`
+- next boundary: `music_transformer_solo_yield_repaired_progression_retry_sweep`
 
 ## 결과 파일
 
@@ -183,6 +185,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/solo_yield_dead_air_repair_sweep.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/solo_yield_dead_air_repair_sweep.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`
@@ -205,6 +209,7 @@ Report:
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_handoff_audit/issue_1316_interval_contour_handoff_audit/interval_contour_handoff_reproducibility_audit.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/solo_yield_dead_air_repair_sweep.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -253,6 +258,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_INTERVAL_CONTOUR_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_FAILURE_CASE_REVIEW_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md
@@ -1,0 +1,38 @@
+# Stage B MIDI-to-Solo Dead-Air Repair Sweep
+
+## Summary
+
+- source case: `rhythm_turnaround`
+- chords: `Bbmaj7,G7,Cm7,F7`
+- source strict: `1` / `3`
+- best strict: `3` / `3`
+- strict delta: `2`
+- source dead-air fails: `2`
+- best dead-air fails: `0`
+- selected variant: `fill_n9`
+- selected duration mode: `fill`
+- selected note groups per bar: `9`
+- rendered WAV files: `2`
+- repair improved: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_repaired_progression_retry_sweep`
+
+## Variants
+
+| variant | duration | groups/bar | strict | grammar | dead-air fails | avg dead-air | avg removal | WAV |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| `fill_n8` | `fill` | 8 | 1/3 | 3/3 | 2 | 0.7854 | 0.1354 | 2 |
+| `fill_n9` | `fill` | 9 | 3/3 | 3/3 | 0 | 0.6409 | 0.1481 | 2 |
+| `fill_n10` | `fill` | 10 | 3/3 | 3/3 | 0 | 0.6701 | 0.1574 | 2 |
+
+## Best Variant WAV Files
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/packages/rhythm_turnaround_fill_n9/audio/candidate_01_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/packages/rhythm_turnaround_fill_n9/audio/candidate_02_sample_01.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `full_progression_retry_sweep`
+- `artist_level_long_solo_generation`


### PR DESCRIPTION
## Summary

- sampling dead-air repair sweep 결과 기록
- rhythm_turnaround failing case 대상 fill variants 비교
- best variant, strict yield, dead-air fail delta 기록
- README 최신 evidence 갱신

## Context

- #1320 sampling failure review 결과
- failing case count: `1`
- reviewed invalid sample count: `2`
- dead-air fail count: `2`
- selected repair target: `duration_fill_or_overlap_aftercare`
- next boundary: `music_transformer_solo_yield_dead_air_repair_sweep`

## Scope

- variants: `fill_n8`, `fill_n9`, `fill_n10`
- sample count: `3`
- bars: `4`
- best variant package/WAV 결과 기록
- quality claim false 유지

## Validation

- `.venv/bin/python scripts/run_music_transformer_solo_yield_dead_air_repair_sweep.py --failure_review outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.json --run_id issue_1322_sampling_dead_air_repair --doc_path docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md --case_label rhythm_turnaround --sample_count 3 --bars 4 --top_n 2 --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- source strict: `1 / 3`
- best strict: `3 / 3`
- strict delta: `2`
- source dead-air fail count: `2`
- best dead-air fail count: `0`
- dead-air fail delta: `2`
- selected variant: `fill_n9`
- selected note groups per bar: `9`
- rendered WAV files: `2`
- repair improved: `true`
- best variant all strict valid: `true`
- next boundary: `music_transformer_solo_yield_repaired_progression_retry_sweep`
- musical quality claim: `false`

## Risk

- full progression retry 미검증
- 청취 선호 입력 미포함
- repair 결과의 음악적 품질 판단 제외

## Follow-up

- repaired progression retry sweep

Closes #1322