### PR TITLE
Stage B MIDI-to-solo sampling repaired progression retry sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- sampling dead-air repair: `rhythm_turnaround` strict `1 / 3 -> 3 / 3`, dead-air fail `2 -> 0`
+- repaired progression retry: grammar/valid/strict `12 / 12`, rendered WAV `8`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -172,6 +172,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_dead_air_repair_sweep`
 - sampling dead-air repair sweep: selected `fill_n9`, strict `1 / 3 -> 3 / 3`, dead-air fail `2 -> 0`, rendered WAV `2`
 - next boundary: `music_transformer_solo_yield_repaired_progression_retry_sweep`
+- repaired progression retry sweep: grammar `12 / 12`, valid `12 / 12`, strict `12 / 12`, min case strict rate `1.0000`, rendered WAV `8`
+- next boundary: `music_transformer_solo_yield_candidate_listening_review`
 
 ## 결과 파일
 
@@ -187,6 +189,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/solo_yield_dead_air_repair_sweep.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/solo_yield_dead_air_repair_sweep.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/solo_yield_sweep_report.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/solo_yield_sweep_report.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`
@@ -210,6 +214,7 @@ Report:
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1318_sampling_repeatability_audit/solo_yield_sweep_report.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/solo_yield_dead_air_repair_sweep.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/solo_yield_sweep_report.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -259,6 +264,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPAIRED_PROGRESSION_RETRY_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPAIRED_PROGRESSION_RETRY_SWEEP_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPAIRED_PROGRESSION_RETRY_SWEEP_2026-06-11.md
@@ -1,0 +1,51 @@
+# Stage B MIDI-to-Solo Chord Progression Yield Sweep
+
+## Summary
+
+- checkpoint generation used: `true`
+- constrained decoding used: `true`
+- case count: `4`
+- sample count: `12`
+- duration mode: `fill`
+- valid yield: `12` / `12`
+- strict yield: `12` / `12`
+- grammar yield: `12` / `12`
+- strict yield rate: `1.0000`
+- min case strict yield rate: `1.0000`
+- selected MIDI candidates: `8`
+- rendered WAV files: `8`
+- total yield floor passed: `true`
+- all case yield floor passed: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_candidate_listening_review`
+
+## Cases
+
+| case | chords | seed | strict | valid | grammar | strict rate | avg notes | avg dead air | package |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 1600 | 3/3 | 3/3 | 3/3 | 1.0000 | 30.67 | 0.6857 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/01_minor_backdoor_seed_1600/solo_yield_package.json` |
+| `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 1617 | 3/3 | 3/3 | 3/3 | 1.0000 | 31.00 | 0.6234 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/02_major_ii_v_turnaround_seed_1617/solo_yield_package.json` |
+| `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 1634 | 3/3 | 3/3 | 3/3 | 1.0000 | 30.00 | 0.6906 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/03_dominant_cycle_seed_1634/solo_yield_package.json` |
+| `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 1651 | 3/3 | 3/3 | 3/3 | 1.0000 | 30.67 | 0.6409 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/04_rhythm_turnaround_seed_1651/solo_yield_package.json` |
+
+## Failing Cases
+
+- `none`
+
+## WAV Files
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/01_minor_backdoor_seed_1600/audio/candidate_01_sample_01.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/01_minor_backdoor_seed_1600/audio/candidate_02_sample_03.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/02_major_ii_v_turnaround_seed_1617/audio/candidate_01_sample_01.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/02_major_ii_v_turnaround_seed_1617/audio/candidate_02_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/03_dominant_cycle_seed_1634/audio/candidate_01_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/03_dominant_cycle_seed_1634/audio/candidate_02_sample_01.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/04_rhythm_turnaround_seed_1651/audio/candidate_01_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/packages/04_rhythm_turnaround_seed_1651/audio/candidate_02_sample_01.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary

- repaired progression retry sweep 결과 기록
- #1322 best variant 조건을 전체 progression에 적용
- grammar/valid/strict yield 12/12 회복 확인
- top2 package/WAV 8개 생성 기록
- README 최신 evidence 갱신

## Context

- #1322 dead-air repair sweep 결과
- selected variant: `fill_n9`
- selected note groups per bar: `9`
- source strict: `1 / 3`
- best strict: `3 / 3`
- dead-air fail: `2 -> 0`
- next boundary: `music_transformer_solo_yield_repaired_progression_retry_sweep`

## Scope

- 4 progression x 3 samples retry sweep
- bars: `4`
- duration mode: `fill`
- note groups/bar: `9`
- top_n: `2`
- package/WAV 생성 포함

## Validation

- `.venv/bin/python scripts/run_music_transformer_solo_yield_sweep.py --run_id issue_1324_sampling_repaired_retry --doc_path docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPAIRED_PROGRESSION_RETRY_SWEEP_2026-06-11.md --sample_count 3 --bars 4 --duration_mode fill --note_groups_per_bar 9 --seed_start 1600 --seed_stride 17 --top_n 2 --min_cases 4 --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- case count: `4`
- sample count: `12`
- grammar gate sample count: `12`
- valid sample count: `12`
- strict valid sample count: `12`
- strict yield rate: `1.0000`
- min case strict yield rate: `1.0000`
- selected MIDI candidates: `8`
- rendered WAV files: `8`
- total yield floor passed: `true`
- all case yield floor passed: `true`
- next boundary: `music_transformer_solo_yield_candidate_listening_review`
- musical quality claim: `false`

## Risk

- 청취 선호 입력 미포함
- 음악적 품질 판단 범위 제외
- retry sample count는 case당 3개로 제한

## Follow-up

- candidate listening review package

Closes #1324