### PR TITLE
Stage B MIDI-to-solo repaired retry candidate listening package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- repaired progression retry: grammar/valid/strict `12 / 12`, rendered WAV `8`
+- repaired retry listening package: MIDI `8`, WAV `8`, review input template ready
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -174,6 +174,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_repaired_progression_retry_sweep`
 - repaired progression retry sweep: grammar `12 / 12`, valid `12 / 12`, strict `12 / 12`, min case strict rate `1.0000`, rendered WAV `8`
 - next boundary: `music_transformer_solo_yield_candidate_listening_review`
+- repaired retry listening package: candidate MIDI `8`, candidate WAV `8`, validated listening input `false`
+- next boundary: `music_transformer_solo_yield_listening_input_guard`
 
 ## 결과 파일
 
@@ -191,6 +193,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/solo_yield_dead_air_repair_sweep.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/solo_yield_sweep_report.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/solo_yield_sweep_report.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_package.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_package.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_input_template.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`
@@ -215,6 +220,7 @@ Report:
 - `outputs/music_transformer_finetune_mvp/solo_yield_failure_review/issue_1320_sampling_failure_review/solo_yield_failure_review.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/solo_yield_dead_air_repair_sweep.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/solo_yield_sweep_report.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_package.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -265,6 +271,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPAIRED_PROGRESSION_RETRY_SWEEP_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LISTENING_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LISTENING_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LISTENING_PACKAGE_2026-06-11.md
@@ -1,0 +1,37 @@
+# Music Transformer Solo Yield Listening Review Package
+
+## Summary
+
+- source strict yield: `12` / `12`
+- source strict yield rate: `1.0000`
+- source rendered audio files: `8`
+- review candidate count: `8`
+- MIDI files copied: `8`
+- WAV files copied: `8`
+- validated listening input present: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_listening_input_guard`
+
+## Candidates
+
+| review | case | chords | score | notes | dead air | WAV | MIDI |
+|---:|---|---|---:|---:|---:|---|---|
+| 1 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 232.983 | 32 | 0.6774 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_01_minor_backdoor_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/midi/candidate_01_minor_backdoor_rank_01.mid` |
+| 2 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 231.043 | 33 | 0.6875 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_02_minor_backdoor_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/midi/candidate_02_minor_backdoor_rank_02.mid` |
+| 3 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 232.814 | 32 | 0.5806 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_03_major_ii_v_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/midi/candidate_03_major_ii_v_turnaround_rank_01.mid` |
+| 4 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 232.718 | 31 | 0.6000 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/midi/candidate_04_major_ii_v_turnaround_rank_02.mid` |
+| 5 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 232.135 | 29 | 0.7143 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_05_dominant_cycle_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/midi/candidate_05_dominant_cycle_rank_01.mid` |
+| 6 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 232.083 | 31 | 0.6333 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_06_dominant_cycle_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/midi/candidate_06_dominant_cycle_rank_02.mid` |
+| 7 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 233.871 | 31 | 0.5667 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_07_rhythm_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/midi/candidate_07_rhythm_turnaround_rank_01.mid` |
+| 8 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 231.892 | 29 | 0.6786 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_08_rhythm_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/midi/candidate_08_rhythm_turnaround_rank_02.mid` |
+
+## Review Input
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_input_template.json`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary

- repaired retry candidate listening package 결과 기록
- top2 per progression 후보 8개를 단일 package로 복사
- review input template 작성
- README 최신 evidence 갱신

## Context

- #1324 repaired progression retry 결과
- grammar/valid/strict: `12 / 12`
- selected MIDI candidates: `8`
- rendered WAV files: `8`
- next boundary: `music_transformer_solo_yield_candidate_listening_review`

## Scope

- existing listening package builder 실행
- max candidates: `8`
- MIDI/WAV copy count 검증
- review input template 생성
- quality claim false 유지

## Validation

- `.venv/bin/python scripts/build_music_transformer_solo_yield_listening_package.py --sweep_report outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/solo_yield_sweep_report.json --run_id issue_1326_repaired_retry_listening_package --doc_path docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LISTENING_PACKAGE_2026-06-11.md --max_candidates 8 --min_candidates 8 --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- candidate count: `8`
- candidate MIDI files copied: `8`
- candidate WAV files copied: `8`
- listening review package ready: `true`
- validated listening input present: `false`
- next boundary: `music_transformer_solo_yield_listening_input_guard`
- musical quality claim: `false`

## Risk

- 청취 선호 입력 미포함
- 음악적 품질 판단 범위 제외
- 다음 input guard에서 pending review 상태 확인 필요

## Follow-up

- listening input guard

Closes #1326