### PR TITLE
Stage B MIDI-to-solo repaired retry listening input guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- repaired retry listening package: MIDI `8`, WAV `8`, review input template ready
+- repaired retry input guard: pending candidate fields `24`, next `objective_only_next_decision`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -176,6 +176,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_candidate_listening_review`
 - repaired retry listening package: candidate MIDI `8`, candidate WAV `8`, validated listening input `false`
 - next boundary: `music_transformer_solo_yield_listening_input_guard`
+- repaired retry listening input guard: validated input `false`, preference fill `false`, pending candidate fields `24`
+- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
 
 ## 결과 파일
 
@@ -196,6 +198,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_input_template.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1328_repaired_listening_input_guard/listening_input_guard.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1328_repaired_listening_input_guard/listening_input_guard.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`
@@ -221,6 +225,7 @@ Report:
 - `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_repair_sweep/issue_1322_sampling_dead_air_repair/solo_yield_dead_air_repair_sweep.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1324_sampling_repaired_retry/solo_yield_sweep_report.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_package.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1328_repaired_listening_input_guard/listening_input_guard.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -272,6 +277,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_SAMPLING_REPAIRED_PROGRESSION_RETRY_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LISTENING_PACKAGE_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LISTENING_INPUT_GUARD_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LISTENING_INPUT_GUARD_2026-06-11.md
@@ -1,0 +1,32 @@
+# Music Transformer Solo Yield Listening Input Guard
+
+## Summary
+
+- source candidate count: `8`
+- listening input path: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_input_template.json`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- objective-only next decision required: `true`
+- pending status: `true`
+- pending overall decision: `true`
+- pending candidate field count: `24`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
+
+## Pending Candidate Fields
+
+- review `1`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `2`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `3`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `4`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `5`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `6`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `7`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `8`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary

- repaired retry listening input guard 결과 기록
- pending review input 상태 검증
- preference fill false 유지
- objective-only next decision boundary 기록
- README 최신 evidence 갱신

## Context

- #1326 listening package 결과
- candidate count: `8`
- candidate MIDI files copied: `8`
- candidate WAV files copied: `8`
- validated listening input present: `false`
- next boundary: `music_transformer_solo_yield_listening_input_guard`

## Scope

- existing input guard script 실행
- review input template pending field count 기록
- quality claim false 유지
- README evidence 갱신

## Validation

- `.venv/bin/python scripts/guard_music_transformer_solo_yield_listening_input.py --package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_package.json --run_id issue_1328_repaired_listening_input_guard --doc_path docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LISTENING_INPUT_GUARD_2026-06-11.md --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- validated listening input present: `false`
- preference fill allowed: `false`
- objective-only next decision required: `true`
- pending status: `true`
- pending overall decision: `true`
- pending candidate field count: `24`
- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
- musical quality claim: `false`

## Risk

- 청취 선호 입력 미포함
- 음악적 품질 판단 범위 제외
- 다음 objective-only decision에서 metric 기준 후속 여부 결정 필요

## Follow-up

- objective-only next decision

Closes #1328