### PR TITLE
Stage B MIDI-to-solo repaired retry objective-only next decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- repaired retry input guard: pending candidate fields `24`, next `objective_only_next_decision`
+- repaired retry objective-only decision: candidate `8`, selected `4`, next `larger_sample_repeatability_sweep`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -178,6 +178,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_listening_input_guard`
 - repaired retry listening input guard: validated input `false`, preference fill `false`, pending candidate fields `24`
 - next boundary: `music_transformer_solo_yield_objective_only_next_decision`
+- repaired retry objective-only decision: candidate `8`, selected objective candidates `4`, score range `231.043 - 233.871`
+- repaired retry objective-only decision claim boundary: musical quality claim `false`, artist style claim `false`
+- next boundary: `music_transformer_solo_yield_larger_sample_repeatability_sweep`
 
 ## 결과 파일
 
@@ -200,6 +203,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_input_template.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1328_repaired_listening_input_guard/listening_input_guard.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1328_repaired_listening_input_guard/listening_input_guard.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1330_repaired_objective_next/objective_next_decision.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1330_repaired_objective_next/objective_next_decision.json`
+- `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`

--- a/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
@@ -1,0 +1,29 @@
+# Music Transformer Solo Yield Objective-Only Next Decision
+
+## Summary
+
+- candidate count: `8`
+- selected objective candidates: `4`
+- score range: `231.043` - `233.871`
+- note count range: `29` - `33`
+- dead-air range: `0.5667` - `0.7143`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_larger_sample_repeatability_sweep`
+
+## Selected Objective Candidates
+
+| review | case | score | notes | dead air | WAV |
+|---:|---|---:|---:|---:|---|
+| 7 | `rhythm_turnaround` | 233.871 | 31 | 0.5667 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_07_rhythm_turnaround_rank_01.wav` |
+| 1 | `minor_backdoor` | 232.983 | 32 | 0.6774 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_01_minor_backdoor_rank_01.wav` |
+| 3 | `major_ii_v_turnaround` | 232.814 | 32 | 0.5806 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_03_major_ii_v_turnaround_rank_01.wav` |
+| 4 | `major_ii_v_turnaround` | 232.718 | 31 | 0.6000 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_02.wav` |
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary

- repaired retry listening input guard 이후 objective-only next decision 기록
- 후보 8개 중 objective 기준 selected candidates 4개 기록
- next boundary: `music_transformer_solo_yield_larger_sample_repeatability_sweep`
- README 최신 evidence 및 결과 파일 경로 갱신

## Context

- #1328 input guard 결과: validated input `false`, preference fill `false`, pending candidate fields `24`
- #1324 repaired progression retry sweep 결과: grammar `12 / 12`, valid `12 / 12`, strict `12 / 12`
- 청취 입력 전 musical quality claim 제외

## Validation

- `.venv/bin/python scripts/decide_music_transformer_solo_yield_objective_next.py --package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1326_repaired_retry_listening_package/listening_review_package.json --guard_report outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1328_repaired_listening_input_guard/listening_input_guard.json --run_id issue_1330_repaired_objective_next --doc_path docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md --top_n 4 --pending_next_boundary music_transformer_solo_yield_larger_sample_repeatability_sweep --pending_reason "listening input pending; repaired retry yield is clean, so increase sample count before quality claim" --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human audio preference: not proven
- stable jazz solo quality: not proven
- artist-level long solo generation: not proven

Closes #1330