### PR TITLE
Stage B MIDI-to-solo repaired retry larger sample repeatability sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- repaired retry objective-only decision: candidate `8`, selected `4`, next `larger_sample_repeatability_sweep`
+- repaired retry larger sample sweep: strict `24 / 24`, grammar-valid `24 / 24`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -181,6 +181,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - repaired retry objective-only decision: candidate `8`, selected objective candidates `4`, score range `231.043 - 233.871`
 - repaired retry objective-only decision claim boundary: musical quality claim `false`, artist style claim `false`
 - next boundary: `music_transformer_solo_yield_larger_sample_repeatability_sweep`
+- repaired retry larger sample repeatability: strict `24 / 24`, grammar-valid `24 / 24`, min case strict rate `1.0000`
+- repaired retry larger sample package: selected MIDI `8`, rendered WAV `8`, musical quality claim `false`
+- next boundary: `music_transformer_solo_yield_candidate_listening_review`
 
 ## 결과 파일
 
@@ -206,6 +209,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1330_repaired_objective_next/objective_next_decision.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1330_repaired_objective_next/objective_next_decision.json`
 - `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/solo_yield_sweep_report.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/solo_yield_sweep_report.json`
+- `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`

--- a/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md
@@ -1,0 +1,51 @@
+# Stage B MIDI-to-Solo Chord Progression Yield Sweep
+
+## Summary
+
+- checkpoint generation used: `true`
+- constrained decoding used: `true`
+- case count: `4`
+- sample count: `24`
+- duration mode: `fill`
+- valid yield: `24` / `24`
+- strict yield: `24` / `24`
+- grammar yield: `24` / `24`
+- strict yield rate: `1.0000`
+- min case strict yield rate: `1.0000`
+- selected MIDI candidates: `8`
+- rendered WAV files: `8`
+- total yield floor passed: `true`
+- all case yield floor passed: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_candidate_listening_review`
+
+## Cases
+
+| case | chords | seed | strict | valid | grammar | strict rate | avg notes | avg dead air | package |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 1900 | 6/6 | 6/6 | 6/6 | 1.0000 | 30.50 | 0.6682 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/01_minor_backdoor_seed_1900/solo_yield_package.json` |
+| `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 1923 | 6/6 | 6/6 | 6/6 | 1.0000 | 30.50 | 0.6442 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/02_major_ii_v_turnaround_seed_1923/solo_yield_package.json` |
+| `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 1946 | 6/6 | 6/6 | 6/6 | 1.0000 | 30.67 | 0.6532 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/03_dominant_cycle_seed_1946/solo_yield_package.json` |
+| `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 1969 | 6/6 | 6/6 | 6/6 | 1.0000 | 29.83 | 0.6842 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/04_rhythm_turnaround_seed_1969/solo_yield_package.json` |
+
+## Failing Cases
+
+- `none`
+
+## WAV Files
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/01_minor_backdoor_seed_1900/audio/candidate_01_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/01_minor_backdoor_seed_1900/audio/candidate_02_sample_05.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/02_major_ii_v_turnaround_seed_1923/audio/candidate_01_sample_03.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/02_major_ii_v_turnaround_seed_1923/audio/candidate_02_sample_05.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/03_dominant_cycle_seed_1946/audio/candidate_01_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/03_dominant_cycle_seed_1946/audio/candidate_02_sample_05.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/04_rhythm_turnaround_seed_1969/audio/candidate_01_sample_01.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/packages/04_rhythm_turnaround_seed_1969/audio/candidate_02_sample_04.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary

- repaired retry 설정 기준 larger sample repeatability sweep 기록
- 4개 progression case, 총 24개 샘플 검증
- strict `24 / 24`, grammar `24 / 24`, min case strict rate `1.0000`
- selected MIDI `8`, rendered WAV `8`
- README 최신 evidence 및 결과 파일 경로 갱신

## Context

- #1330 objective-only decision 결과: next boundary `music_transformer_solo_yield_larger_sample_repeatability_sweep`
- #1324 repaired retry sweep 결과: strict `12 / 12`
- 청취 입력 전 musical quality claim 제외

## Validation

- `.venv/bin/python scripts/run_music_transformer_solo_yield_sweep.py --run_id issue_1332_repaired_larger_sample_repeatability --doc_path docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md --sample_count 6 --bars 4 --duration_mode fill --note_groups_per_bar 9 --seed_start 1900 --seed_stride 23 --top_n 2 --min_cases 4 --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human audio preference: not proven
- stable jazz solo quality: not proven
- artist-level long solo generation: not proven

Closes #1332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new completion metrics for the repaired larger sample sweep, showing validation results.
  * Added comprehensive documentation for Stage B MIDI-to-Solo sweep results, including test configuration, validation metrics, and output artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->