### PR TITLE
Stage B MIDI-to-solo larger sample listening review package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- repaired retry larger sample sweep: strict `24 / 24`, grammar-valid `24 / 24`
+- larger sample listening package: MIDI `8`, WAV `8`, next `listening_input_guard`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -184,6 +184,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - repaired retry larger sample repeatability: strict `24 / 24`, grammar-valid `24 / 24`, min case strict rate `1.0000`
 - repaired retry larger sample package: selected MIDI `8`, rendered WAV `8`, musical quality claim `false`
 - next boundary: `music_transformer_solo_yield_candidate_listening_review`
+- larger sample listening package: MIDI `8`, WAV `8`, review input template ready `true`
+- larger sample listening package claim boundary: validated listening input `false`, musical quality claim `false`
+- next boundary: `music_transformer_solo_yield_listening_input_guard`
 
 ## 결과 파일
 
@@ -212,6 +215,10 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/solo_yield_sweep_report.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/solo_yield_sweep_report.json`
 - `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_RETRY_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/listening_review_package.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/listening_review_package.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/listening_review_input_template.json`
+- `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`

--- a/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md
@@ -2,12 +2,12 @@
 
 ## Summary
 
-- source strict yield: `47` / `48`
-- source strict yield rate: `0.9792`
-- source rendered audio files: `12`
-- review candidate count: `12`
-- MIDI files copied: `12`
-- WAV files copied: `12`
+- source strict yield: `24` / `24`
+- source strict yield rate: `1.0000`
+- source rendered audio files: `8`
+- review candidate count: `8`
+- MIDI files copied: `8`
+- WAV files copied: `8`
 - validated listening input present: `false`
 - musical quality claimed: `false`
 - next boundary: `music_transformer_solo_yield_listening_input_guard`
@@ -16,22 +16,18 @@
 
 | review | case | chords | score | notes | dead air | WAV | MIDI |
 |---:|---|---|---:|---:|---:|---|---|
-| 1 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 230.026 | 17 | 0.5625 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_01_minor_backdoor_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_01_minor_backdoor_rank_01.mid` |
-| 2 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 229.765 | 17 | 0.6250 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_02_minor_backdoor_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_02_minor_backdoor_rank_02.mid` |
-| 3 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 228.613 | 17 | 0.4375 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_03_minor_backdoor_rank_03.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_03_minor_backdoor_rank_03.mid` |
-| 4 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 230.283 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_04_major_ii_v_turnaround_rank_01.mid` |
-| 5 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 229.244 | 18 | 0.6471 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_05_major_ii_v_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_05_major_ii_v_turnaround_rank_02.mid` |
-| 6 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 228.966 | 17 | 0.5625 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_06_major_ii_v_turnaround_rank_03.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_06_major_ii_v_turnaround_rank_03.mid` |
-| 7 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 230.626 | 19 | 0.5000 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_07_dominant_cycle_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_07_dominant_cycle_rank_01.mid` |
-| 8 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 230.020 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_08_dominant_cycle_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_08_dominant_cycle_rank_02.mid` |
-| 9 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 229.321 | 17 | 0.5625 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_09_dominant_cycle_rank_03.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_09_dominant_cycle_rank_03.mid` |
-| 10 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 231.259 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_10_rhythm_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_10_rhythm_turnaround_rank_01.mid` |
-| 11 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 229.886 | 18 | 0.5294 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_11_rhythm_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_11_rhythm_turnaround_rank_02.mid` |
-| 12 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 229.321 | 17 | 0.6250 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_12_rhythm_turnaround_rank_03.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_12_rhythm_turnaround_rank_03.mid` |
+| 1 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 232.503 | 31 | 0.6333 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_01_minor_backdoor_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/midi/candidate_01_minor_backdoor_rank_01.mid` |
+| 2 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 231.179 | 30 | 0.6552 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_02_minor_backdoor_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/midi/candidate_02_minor_backdoor_rank_02.mid` |
+| 3 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 233.777 | 28 | 0.6667 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_03_major_ii_v_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/midi/candidate_03_major_ii_v_turnaround_rank_01.mid` |
+| 4 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 233.536 | 32 | 0.6452 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/midi/candidate_04_major_ii_v_turnaround_rank_02.mid` |
+| 5 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 233.432 | 30 | 0.5517 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_05_dominant_cycle_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/midi/candidate_05_dominant_cycle_rank_01.mid` |
+| 6 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 233.055 | 30 | 0.7931 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_06_dominant_cycle_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/midi/candidate_06_dominant_cycle_rank_02.mid` |
+| 7 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 233.845 | 30 | 0.5862 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_07_rhythm_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/midi/candidate_07_rhythm_turnaround_rank_01.mid` |
+| 8 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 232.687 | 29 | 0.7143 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_08_rhythm_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/midi/candidate_08_rhythm_turnaround_rank_02.mid` |
 
 ## Review Input
 
-- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/listening_review_input_template.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/listening_review_input_template.json`
 
 ## Not Proven
 


### PR DESCRIPTION
## Summary

- #1332 larger sample sweep 결과 기반 listening review package 갱신
- MIDI 후보 `8`, WAV 후보 `8`, review input template 경로 기록
- next boundary: `music_transformer_solo_yield_listening_input_guard`
- README 최신 evidence 및 결과 파일 경로 갱신

## Context

- #1332 larger sample repeatability sweep 결과: strict `24 / 24`, grammar `24 / 24`, min case strict rate `1.0000`
- selected MIDI `8`, rendered WAV `8`
- 청취 입력 전 musical quality claim 제외

## Validation

- `.venv/bin/python scripts/build_music_transformer_solo_yield_listening_package.py --sweep_report outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1332_repaired_larger_sample_repeatability/solo_yield_sweep_report.json --run_id issue_1334_larger_sample_listening_package --doc_path docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md --max_candidates 8 --min_candidates 8 --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human audio preference: not proven
- stable jazz solo quality: not proven
- artist-level long solo generation: not proven

Closes #1334