### PR TITLE
Stage B MIDI-to-solo larger sample listening input guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- larger sample listening package: MIDI `8`, WAV `8`, next `listening_input_guard`
+- larger sample input guard: pending candidate fields `24`, next `objective_only_next_decision`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -187,6 +187,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - larger sample listening package: MIDI `8`, WAV `8`, review input template ready `true`
 - larger sample listening package claim boundary: validated listening input `false`, musical quality claim `false`
 - next boundary: `music_transformer_solo_yield_listening_input_guard`
+- larger sample input guard: validated input `false`, preference fill `false`, pending candidate fields `24`
+- larger sample input guard decision: objective-only next decision required `true`, musical quality claim `false`
+- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
 
 ## 결과 파일
 
@@ -219,6 +222,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/listening_review_input_template.json`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1336_larger_sample_input_guard/listening_input_guard.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1336_larger_sample_input_guard/listening_input_guard.json`
+- `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`

--- a/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md
@@ -2,14 +2,14 @@
 
 ## Summary
 
-- source candidate count: `12`
-- listening input path: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/listening_review_input_template.json`
+- source candidate count: `8`
+- listening input path: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/listening_review_input_template.json`
 - validated listening input present: `false`
 - preference fill allowed: `false`
 - objective-only next decision required: `true`
 - pending status: `true`
 - pending overall decision: `true`
-- pending candidate field count: `36`
+- pending candidate field count: `24`
 - musical quality claimed: `false`
 - next boundary: `music_transformer_solo_yield_objective_only_next_decision`
 
@@ -23,10 +23,6 @@
 - review `6`: `decision,usable_as_jazz_solo_phrase,primary_failure`
 - review `7`: `decision,usable_as_jazz_solo_phrase,primary_failure`
 - review `8`: `decision,usable_as_jazz_solo_phrase,primary_failure`
-- review `9`: `decision,usable_as_jazz_solo_phrase,primary_failure`
-- review `10`: `decision,usable_as_jazz_solo_phrase,primary_failure`
-- review `11`: `decision,usable_as_jazz_solo_phrase,primary_failure`
-- review `12`: `decision,usable_as_jazz_solo_phrase,primary_failure`
 
 ## Not Proven
 


### PR DESCRIPTION
## Summary

- #1334 larger sample listening package 기준 input guard 결과 기록
- validated input `false`, preference fill `false`
- pending candidate fields `24`
- objective-only next decision required `true`
- README 최신 evidence 및 결과 파일 경로 갱신

## Context

- #1334 listening package 결과: MIDI `8`, WAV `8`, review input template ready
- 청취 입력 전 preference fill 및 musical quality claim 제외 필요

## Validation

- `.venv/bin/python scripts/guard_music_transformer_solo_yield_listening_input.py --package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/listening_review_package.json --run_id issue_1336_larger_sample_input_guard --doc_path docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human audio preference: not proven
- stable jazz solo quality: not proven
- artist-level long solo generation: not proven

Closes #1336