### PR TITLE
Stage B MIDI-to-solo larger sample objective-only next decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- larger sample input guard: pending candidate fields `24`, next `objective_only_next_decision`
+- larger sample objective decision: candidate `8`, selected `4`, next `final_review_handoff`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -190,6 +190,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - larger sample input guard: validated input `false`, preference fill `false`, pending candidate fields `24`
 - larger sample input guard decision: objective-only next decision required `true`, musical quality claim `false`
 - next boundary: `music_transformer_solo_yield_objective_only_next_decision`
+- larger sample objective-only decision: candidate `8`, selected objective candidates `4`, score range `231.179 - 233.845`
+- larger sample objective-only decision claim boundary: musical quality claim `false`, artist style claim `false`
+- next boundary: `music_transformer_solo_yield_larger_sample_final_review_handoff`
 
 ## 결과 파일
 
@@ -225,6 +228,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1336_larger_sample_input_guard/listening_input_guard.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1336_larger_sample_input_guard/listening_input_guard.json`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1338_larger_sample_objective_next/objective_next_decision.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1338_larger_sample_objective_next/objective_next_decision.json`
+- `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`

--- a/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
@@ -2,26 +2,24 @@
 
 ## Summary
 
-- candidate count: `12`
-- selected objective candidates: `6`
-- score range: `228.613` - `231.259`
-- note count range: `17` - `19`
-- dead-air range: `0.4375` - `0.6471`
+- candidate count: `8`
+- selected objective candidates: `4`
+- score range: `231.179` - `233.845`
+- note count range: `28` - `32`
+- dead-air range: `0.5517` - `0.7931`
 - validated listening input present: `false`
 - preference fill allowed: `false`
 - musical quality claimed: `false`
-- next boundary: `music_transformer_solo_yield_4bar_phrase_expansion_probe`
+- next boundary: `music_transformer_solo_yield_larger_sample_final_review_handoff`
 
 ## Selected Objective Candidates
 
 | review | case | score | notes | dead air | WAV |
 |---:|---|---:|---:|---:|---|
-| 10 | `rhythm_turnaround` | 231.259 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_10_rhythm_turnaround_rank_01.wav` |
-| 7 | `dominant_cycle` | 230.626 | 19 | 0.5000 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_07_dominant_cycle_rank_01.wav` |
-| 4 | `major_ii_v_turnaround` | 230.283 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_01.wav` |
-| 1 | `minor_backdoor` | 230.026 | 17 | 0.5625 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_01_minor_backdoor_rank_01.wav` |
-| 8 | `dominant_cycle` | 230.020 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_08_dominant_cycle_rank_02.wav` |
-| 11 | `rhythm_turnaround` | 229.886 | 18 | 0.5294 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_11_rhythm_turnaround_rank_02.wav` |
+| 7 | `rhythm_turnaround` | 233.845 | 30 | 0.5862 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_07_rhythm_turnaround_rank_01.wav` |
+| 3 | `major_ii_v_turnaround` | 233.777 | 28 | 0.6667 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_03_major_ii_v_turnaround_rank_01.wav` |
+| 4 | `major_ii_v_turnaround` | 233.536 | 32 | 0.6452 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_02.wav` |
+| 5 | `dominant_cycle` | 233.432 | 30 | 0.5517 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/audio/candidate_05_dominant_cycle_rank_01.wav` |
 
 ## Not Proven
 


### PR DESCRIPTION
## Summary

- #1336 input guard 이후 objective-only next decision 기록
- 후보 8개 중 objective 기준 selected candidates 4개 기록
- next boundary: `music_transformer_solo_yield_larger_sample_final_review_handoff`
- README 최신 evidence 및 결과 파일 경로 갱신

## Context

- #1336 input guard 결과: validated input `false`, preference fill `false`, pending candidate fields `24`
- #1332 larger sample sweep 결과: strict `24 / 24`, grammar `24 / 24`, min case strict rate `1.0000`
- #1334 listening package 결과: MIDI `8`, WAV `8`
- 청취 입력 전 musical quality claim 제외

## Validation

- `.venv/bin/python scripts/decide_music_transformer_solo_yield_objective_next.py --package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1334_larger_sample_listening_package/listening_review_package.json --guard_report outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1336_larger_sample_input_guard/listening_input_guard.json --run_id issue_1338_larger_sample_objective_next --doc_path docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md --top_n 4 --pending_next_boundary music_transformer_solo_yield_larger_sample_final_review_handoff --pending_reason "listening input pending; larger sample strict yield is clean, so package final review handoff before quality claim" --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human audio preference: not proven
- stable jazz solo quality: not proven
- artist-level long solo generation: not proven

Closes #1338