### PR TITLE
Stage B MIDI-to-solo larger sample handoff reproducibility audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- larger sample final handoff: MIDI `8`, WAV `8`, checksum mismatch `0`
+- larger sample handoff audit: reproducible `true`, checksum mismatch `0`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -196,6 +196,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - larger sample final review handoff: MIDI `8`, WAV `8`, selected objective candidates `4`
 - larger sample final handoff validation: missing file `0`, checksum mismatch `0`, musical quality claim `false`
 - next boundary: `music_transformer_solo_yield_larger_sample_listening_review`
+- larger sample handoff reproducibility audit: reproducible `true`, missing MIDI/WAV `0 / 0`, checksum mismatch `0 / 0`
+- larger sample handoff audit claim boundary: musical quality claim `false`, stable jazz solo quality `not_proven`
+- next boundary: `music_transformer_solo_yield_broader_repaired_sampling_repeatability_audit`
 
 ## 결과 파일
 
@@ -237,6 +240,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_larger_sample_final_handoff/issue_1340_larger_sample_final_handoff/larger_sample_final_review_handoff.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_larger_sample_final_handoff/issue_1340_larger_sample_final_handoff/larger_sample_final_review_handoff.json`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_FINAL_REVIEW_HANDOFF_2026-06-11.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_larger_sample_handoff_audit/issue_1342_larger_sample_handoff_audit/larger_sample_handoff_reproducibility_audit.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_larger_sample_handoff_audit/issue_1342_larger_sample_handoff_audit/larger_sample_handoff_reproducibility_audit.json`
+- `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`

--- a/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md
@@ -1,0 +1,65 @@
+# Music Transformer Solo Yield Larger Sample Handoff Reproducibility Audit
+
+## Summary
+
+- boundary: `music_transformer_solo_yield_larger_sample_handoff_reproducibility_audit`
+- candidate count: `8`
+- selected objective candidates: `4`
+- missing MIDI/WAV: `0` / `0`
+- checksum mismatch MIDI/WAV: `0` / `0`
+- duration range seconds: `10.7000` - `10.7392`
+- sample rates: `44100`
+- reproducible handoff: `true`
+- selected next target: `broader_repaired_sampling_repeatability_audit`
+- next boundary: `music_transformer_solo_yield_broader_repaired_sampling_repeatability_audit`
+- musical quality claimed: `false`
+
+## Candidate File Audit
+
+- candidate `1` / `minor_backdoor`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7378`
+  - selected by objective: `false`
+- candidate `2` / `minor_backdoor`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7000`
+  - selected by objective: `false`
+- candidate `3` / `major_ii_v_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7349`
+  - selected by objective: `true`
+- candidate `4` / `major_ii_v_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7349`
+  - selected by objective: `true`
+- candidate `5` / `dominant_cycle`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7392`
+  - selected by objective: `true`
+- candidate `6` / `dominant_cycle`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7349`
+  - selected by objective: `false`
+- candidate `7` / `rhythm_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7029`
+  - selected by objective: `true`
+- candidate `8` / `rhythm_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7378`
+  - selected by objective: `false`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/audit_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py
+++ b/scripts/audit_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py
@@ -1,0 +1,360 @@
+"""Audit reproducibility of the larger-sample final review handoff package."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.build_music_transformer_solo_yield_larger_sample_final_review_handoff import (  # noqa: E402
+    SCHEMA_VERSION as HANDOFF_SCHEMA_VERSION,
+    validate_report as validate_handoff_report,
+)
+from scripts.render_stage_b_midi_to_solo_candidate_audio import sha256_file, wav_meta  # noqa: E402
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_larger_sample_handoff_reproducibility_audit_v1"
+BOUNDARY = "music_transformer_solo_yield_larger_sample_handoff_reproducibility_audit"
+NEXT_BOUNDARY = "music_transformer_solo_yield_broader_repaired_sampling_repeatability_audit"
+
+
+class SoloYieldLargerSampleHandoffReproducibilityAuditError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_no_quality_claim(report: dict[str, Any]) -> None:
+    readiness = _dict(report.get("readiness"))
+    claimed = [
+        key
+        for key in (
+            "audio_rendered_quality_claimed",
+            "musical_quality_claimed",
+            "artist_style_claimed",
+            "production_ready_claimed",
+        )
+        if bool(readiness.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError(
+            f"unexpected quality claim: {claimed}"
+        )
+
+
+def validate_source_handoff(
+    handoff_report: dict[str, Any],
+    *,
+    expected_candidate_count: int,
+    expected_selected_count: int,
+) -> dict[str, Any]:
+    if str(handoff_report.get("schema_version") or "") != HANDOFF_SCHEMA_VERSION:
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError("handoff schema required")
+    try:
+        summary = validate_handoff_report(handoff_report, require_no_quality_claim=True)
+    except ValueError as exc:
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError(str(exc)) from exc
+    if _int(summary.get("candidate_count")) != int(expected_candidate_count):
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError("candidate count mismatch")
+    if _int(summary.get("midi_count")) != int(expected_candidate_count):
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError("MIDI count mismatch")
+    if _int(summary.get("wav_count")) != int(expected_candidate_count):
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError("WAV count mismatch")
+    if _int(summary.get("selected_objective_candidate_count")) != int(expected_selected_count):
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError(
+            "selected objective candidate count mismatch"
+        )
+    if _int(summary.get("missing_file_count")) != 0:
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError("source missing file count must be zero")
+    if _int(summary.get("checksum_mismatch_count")) != 0:
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError(
+            "source checksum mismatch count must be zero"
+        )
+    return summary
+
+
+def audit_candidate_files(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    audit_rows: list[dict[str, Any]] = []
+    for row in rows:
+        review_index = _int(row.get("review_index"))
+        midi_path = Path(str(row.get("review_midi_path") or ""))
+        wav_path = Path(str(row.get("review_wav_path") or ""))
+        midi_exists = midi_path.exists()
+        wav_exists = wav_path.exists()
+        expected_midi_sha = str(row.get("review_midi_sha256") or "")
+        expected_wav_sha = str(row.get("review_wav_sha256") or "")
+        actual_midi_sha = sha256_file(midi_path) if midi_exists else ""
+        actual_wav_meta = wav_meta(wav_path) if wav_exists else {}
+        actual_wav_sha = str(actual_wav_meta.get("sha256") or "")
+        audit_rows.append(
+            {
+                "review_index": review_index,
+                "case_label": str(row.get("case_label") or ""),
+                "midi_path": str(midi_path),
+                "wav_path": str(wav_path),
+                "midi_exists": midi_exists,
+                "wav_exists": wav_exists,
+                "midi_sha256_matches": bool(expected_midi_sha)
+                and expected_midi_sha == actual_midi_sha,
+                "wav_sha256_matches": bool(expected_wav_sha) and expected_wav_sha == actual_wav_sha,
+                "sample_rate": _int(actual_wav_meta.get("sample_rate")),
+                "duration_seconds": _float(actual_wav_meta.get("duration_seconds")),
+                "selected_by_objective": bool(row.get("selected_by_objective", False)),
+            }
+        )
+    return audit_rows
+
+
+def aggregate_candidate_audit(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    missing_midi = sum(1 for row in rows if not bool(row.get("midi_exists", False)))
+    missing_wav = sum(1 for row in rows if not bool(row.get("wav_exists", False)))
+    midi_mismatch = sum(1 for row in rows if not bool(row.get("midi_sha256_matches", False)))
+    wav_mismatch = sum(1 for row in rows if not bool(row.get("wav_sha256_matches", False)))
+    selected_count = sum(1 for row in rows if bool(row.get("selected_by_objective", False)))
+    durations = [_float(row.get("duration_seconds")) for row in rows]
+    sample_rates = sorted({_int(row.get("sample_rate")) for row in rows})
+    return {
+        "candidate_count": len(rows),
+        "selected_objective_candidate_count": selected_count,
+        "missing_midi_count": missing_midi,
+        "missing_wav_count": missing_wav,
+        "midi_checksum_mismatch_count": midi_mismatch,
+        "wav_checksum_mismatch_count": wav_mismatch,
+        "duration_min_seconds": min(durations, default=0.0),
+        "duration_max_seconds": max(durations, default=0.0),
+        "sample_rates": sample_rates,
+        "reproducible_handoff": (
+            bool(rows)
+            and missing_midi == 0
+            and missing_wav == 0
+            and midi_mismatch == 0
+            and wav_mismatch == 0
+        ),
+    }
+
+
+def build_reproducibility_audit(
+    handoff_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    expected_candidate_count: int,
+    expected_selected_count: int,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source_summary = validate_source_handoff(
+        handoff_report,
+        expected_candidate_count=int(expected_candidate_count),
+        expected_selected_count=int(expected_selected_count),
+    )
+    _require_no_quality_claim(handoff_report)
+    candidate_rows = [_dict(row) for row in _list(handoff_report.get("candidate_handoff"))]
+    if len(candidate_rows) != int(expected_candidate_count):
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError("handoff row count mismatch")
+    candidate_file_audit = audit_candidate_files(candidate_rows)
+    aggregate = aggregate_candidate_audit(candidate_file_audit)
+    if not bool(aggregate.get("reproducible_handoff", False)):
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError(
+            f"handoff reproducibility audit failed: {aggregate}"
+        )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_handoff": {
+            "schema_version": handoff_report.get("schema_version"),
+            "output_dir": handoff_report.get("output_dir"),
+            "candidate_count": _int(source_summary.get("candidate_count")),
+            "midi_count": _int(source_summary.get("midi_count")),
+            "wav_count": _int(source_summary.get("wav_count")),
+            "selected_objective_candidate_count": _int(
+                source_summary.get("selected_objective_candidate_count")
+            ),
+            "source_strict_valid_sample_count": _int(
+                source_summary.get("source_strict_valid_sample_count")
+            ),
+            "source_sample_count": _int(source_summary.get("source_sample_count")),
+            "source_strict_yield_rate": _float(source_summary.get("source_strict_yield_rate")),
+        },
+        "candidate_file_audit": candidate_file_audit,
+        "aggregate": aggregate,
+        "readiness": {
+            "reproducibility_audit_completed": True,
+            "reproducible_handoff": bool(aggregate.get("reproducible_handoff", False)),
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "selected_next_target": "broader_repaired_sampling_repeatability_audit",
+            "next_boundary": NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+            "reason": "larger-sample handoff is reproducible; next objective-only check is broader repaired sampling repeatability",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "artist_level_long_solo_generation",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "larger_sample_handoff_reproducibility_audit.json", report)
+    write_json(
+        output_dir / "larger_sample_handoff_reproducibility_audit_summary.json",
+        validate_report(report, require_no_quality_claim=True),
+    )
+    write_text(output_dir / "larger_sample_handoff_reproducibility_audit.md", markdown_report(report))
+    return report
+
+
+def validate_report(report: dict[str, Any], *, require_no_quality_claim: bool) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldLargerSampleHandoffReproducibilityAuditError("schema version mismatch")
+    if require_no_quality_claim:
+        _require_no_quality_claim(report)
+    readiness = _dict(report.get("readiness"))
+    aggregate = _dict(report.get("aggregate"))
+    decision = _dict(report.get("decision"))
+    return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "boundary": str(report.get("boundary") or ""),
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "selected_objective_candidate_count": _int(
+            aggregate.get("selected_objective_candidate_count")
+        ),
+        "missing_midi_count": _int(aggregate.get("missing_midi_count")),
+        "missing_wav_count": _int(aggregate.get("missing_wav_count")),
+        "midi_checksum_mismatch_count": _int(
+            aggregate.get("midi_checksum_mismatch_count")
+        ),
+        "wav_checksum_mismatch_count": _int(aggregate.get("wav_checksum_mismatch_count")),
+        "reproducible_handoff": bool(readiness.get("reproducible_handoff", False)),
+        "selected_next_target": str(decision.get("selected_next_target") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Music Transformer Solo Yield Larger Sample Handoff Reproducibility Audit",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- selected objective candidates: `{aggregate['selected_objective_candidate_count']}`",
+        f"- missing MIDI/WAV: `{aggregate['missing_midi_count']}` / `{aggregate['missing_wav_count']}`",
+        f"- checksum mismatch MIDI/WAV: `{aggregate['midi_checksum_mismatch_count']}` / `{aggregate['wav_checksum_mismatch_count']}`",
+        f"- duration range seconds: `{float(aggregate['duration_min_seconds']):.4f}` - `{float(aggregate['duration_max_seconds']):.4f}`",
+        f"- sample rates: `{','.join(str(rate) for rate in aggregate['sample_rates'])}`",
+        f"- reproducible handoff: `{_bool_token(readiness['reproducible_handoff'])}`",
+        f"- selected next target: `{decision['selected_next_target']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        "",
+        "## Candidate File Audit",
+        "",
+    ]
+    for row in report.get("candidate_file_audit", []):
+        lines.extend(
+            [
+                f"- candidate `{row['review_index']}` / `{row['case_label']}`",
+                f"  - MIDI exists/checksum: `{_bool_token(row['midi_exists'])}` / `{_bool_token(row['midi_sha256_matches'])}`",
+                f"  - WAV exists/checksum: `{_bool_token(row['wav_exists'])}` / `{_bool_token(row['wav_sha256_matches'])}`",
+                f"  - duration seconds: `{float(row['duration_seconds']):.4f}`",
+                f"  - selected by objective: `{_bool_token(row['selected_by_objective'])}`",
+            ]
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit larger sample final handoff reproducibility")
+    parser.add_argument(
+        "--handoff_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_larger_sample_final_handoff/"
+            "issue_1340_larger_sample_final_handoff/larger_sample_final_review_handoff.json"
+        ),
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_larger_sample_handoff_audit",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_count", type=int, default=8)
+    parser.add_argument("--expected_selected_count", type=int, default=4)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_reproducibility_audit(
+        read_json(Path(args.handoff_report)),
+        output_dir=output_dir,
+        expected_candidate_count=int(args.expected_candidate_count),
+        expected_selected_count=int(args.expected_selected_count),
+    )
+    summary = validate_report(report, require_no_quality_claim=bool(args.require_no_quality_claim))
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py
+++ b/tests/test_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+
+from scripts.audit_music_transformer_solo_yield_larger_sample_handoff_reproducibility import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SCHEMA_VERSION,
+    SoloYieldLargerSampleHandoffReproducibilityAuditError,
+    build_reproducibility_audit,
+    validate_report,
+)
+from scripts.build_music_transformer_solo_yield_larger_sample_final_review_handoff import (
+    SCHEMA_VERSION as HANDOFF_SCHEMA_VERSION,
+)
+from scripts.render_stage_b_midi_to_solo_candidate_audio import sha256_file
+
+
+def touch(path: Path, payload: bytes = b"data") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(44100)
+        handle.writeframes(b"\x00\x00" * 4410)
+
+
+def handoff_report(root: Path, *, quality_claim: bool = False, bad_checksum: bool = False) -> dict:
+    midi_path = root / "handoff" / "midi" / "candidate_01.mid"
+    wav_path = root / "handoff" / "audio" / "candidate_01.wav"
+    touch(midi_path, b"midi")
+    write_wav(wav_path)
+    return {
+        "schema_version": HANDOFF_SCHEMA_VERSION,
+        "output_dir": str(root / "handoff"),
+        "boundary": "music_transformer_solo_yield_larger_sample_final_review_handoff",
+        "candidate_handoff": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "review_midi_path": str(midi_path),
+                "review_wav_path": str(wav_path),
+                "review_midi_sha256": "bad" if bad_checksum else sha256_file(midi_path),
+                "review_wav_sha256": sha256_file(wav_path),
+                "selected_by_objective": True,
+            }
+        ],
+        "aggregate": {
+            "candidate_count": 1,
+            "midi_count": 1,
+            "wav_count": 1,
+            "selected_objective_candidate_count": 1,
+            "source_strict_valid_sample_count": 1,
+            "source_sample_count": 1,
+            "source_strict_yield_rate": 1.0,
+            "missing_file_count": 0,
+            "checksum_mismatch_count": 0,
+        },
+        "readiness": {
+            "final_review_handoff_ready": True,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "selected_next_target": "manual_listening_review_pending",
+            "next_boundary": "music_transformer_solo_yield_larger_sample_listening_review",
+        },
+    }
+
+
+class MusicTransformerSoloYieldLargerSampleHandoffReproducibilityTest(unittest.TestCase):
+    def test_builds_reproducibility_audit_for_ready_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_reproducibility_audit(
+                handoff_report(root),
+                output_dir=root / "out",
+                expected_candidate_count=1,
+                expected_selected_count=1,
+            )
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["boundary"], BOUNDARY)
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["selected_objective_candidate_count"], 1)
+        self.assertEqual(summary["missing_midi_count"], 0)
+        self.assertEqual(summary["missing_wav_count"], 0)
+        self.assertEqual(summary["midi_checksum_mismatch_count"], 0)
+        self.assertEqual(summary["wav_checksum_mismatch_count"], 0)
+        self.assertTrue(summary["reproducible_handoff"])
+        self.assertEqual(summary["selected_next_target"], "broader_repaired_sampling_repeatability_audit")
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertFalse(summary["musical_quality_claimed"])
+
+    def test_rejects_quality_claim_from_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(SoloYieldLargerSampleHandoffReproducibilityAuditError):
+                build_reproducibility_audit(
+                    handoff_report(root, quality_claim=True),
+                    output_dir=root / "out",
+                    expected_candidate_count=1,
+                    expected_selected_count=1,
+                )
+
+    def test_rejects_checksum_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(SoloYieldLargerSampleHandoffReproducibilityAuditError):
+                build_reproducibility_audit(
+                    handoff_report(root, bad_checksum=True),
+                    output_dir=root / "out",
+                    expected_candidate_count=1,
+                    expected_selected_count=1,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- larger sample final handoff reproducibility audit 스크립트 추가
- MIDI/WAV 후보 `8 / 8` 존재 및 checksum 재검증
- missing MIDI/WAV `0 / 0`, checksum mismatch `0 / 0`
- reproducible handoff `true`
- README 최신 evidence 및 audit 결과 경로 갱신

## Context

- #1340 final review handoff 결과: MIDI `8`, WAV `8`, selected objective candidates `4`
- final handoff 산출물의 파일 존재, checksum, WAV metadata 재검증 필요
- 청취 입력 전 musical quality claim 제외

## Validation

- `.venv/bin/python -m unittest tests.test_music_transformer_solo_yield_larger_sample_handoff_reproducibility`
- `.venv/bin/python scripts/audit_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py --handoff_report outputs/music_transformer_finetune_mvp/solo_yield_larger_sample_final_handoff/issue_1340_larger_sample_final_handoff/larger_sample_final_review_handoff.json --run_id issue_1342_larger_sample_handoff_audit --expected_candidate_count 8 --expected_selected_count 4 --doc_path docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human audio preference: not proven
- stable jazz solo quality: not proven
- artist-level long solo generation: not proven

Closes #1342