### PR TITLE
Stage B MIDI-to-solo broader repaired sampling repeatability audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- larger sample handoff audit: reproducible `true`, checksum mismatch `0`
+- broader repaired sampling audit: strict `40 / 40`, grammar-valid `40 / 40`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -199,6 +199,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - larger sample handoff reproducibility audit: reproducible `true`, missing MIDI/WAV `0 / 0`, checksum mismatch `0 / 0`
 - larger sample handoff audit claim boundary: musical quality claim `false`, stable jazz solo quality `not_proven`
 - next boundary: `music_transformer_solo_yield_broader_repaired_sampling_repeatability_audit`
+- broader repaired sampling repeatability: strict `40 / 40`, grammar-valid `40 / 40`, min case strict rate `1.0000`
+- broader repaired sampling package: selected MIDI `8`, rendered WAV `8`, musical quality claim `false`
+- next boundary: `music_transformer_solo_yield_candidate_listening_review`
 
 ## 결과 파일
 
@@ -243,6 +246,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_larger_sample_handoff_audit/issue_1342_larger_sample_handoff_audit/larger_sample_handoff_reproducibility_audit.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_larger_sample_handoff_audit/issue_1342_larger_sample_handoff_audit/larger_sample_handoff_reproducibility_audit.json`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/solo_yield_sweep_report.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/solo_yield_sweep_report.json`
+- `docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`

--- a/docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md
@@ -1,0 +1,51 @@
+# Stage B MIDI-to-Solo Chord Progression Yield Sweep
+
+## Summary
+
+- checkpoint generation used: `true`
+- constrained decoding used: `true`
+- case count: `4`
+- sample count: `40`
+- duration mode: `fill`
+- valid yield: `40` / `40`
+- strict yield: `40` / `40`
+- grammar yield: `40` / `40`
+- strict yield rate: `1.0000`
+- min case strict yield rate: `1.0000`
+- selected MIDI candidates: `8`
+- rendered WAV files: `8`
+- total yield floor passed: `true`
+- all case yield floor passed: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_candidate_listening_review`
+
+## Cases
+
+| case | chords | seed | strict | valid | grammar | strict rate | avg notes | avg dead air | package |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 2300 | 10/10 | 10/10 | 10/10 | 1.0000 | 31.00 | 0.6342 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/01_minor_backdoor_seed_2300/solo_yield_package.json` |
+| `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 2329 | 10/10 | 10/10 | 10/10 | 1.0000 | 30.80 | 0.6543 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/02_major_ii_v_turnaround_seed_2329/solo_yield_package.json` |
+| `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 2358 | 10/10 | 10/10 | 10/10 | 1.0000 | 31.20 | 0.6428 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/03_dominant_cycle_seed_2358/solo_yield_package.json` |
+| `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 2387 | 10/10 | 10/10 | 10/10 | 1.0000 | 30.80 | 0.6655 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/04_rhythm_turnaround_seed_2387/solo_yield_package.json` |
+
+## Failing Cases
+
+- `none`
+
+## WAV Files
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/01_minor_backdoor_seed_2300/audio/candidate_01_sample_08.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/01_minor_backdoor_seed_2300/audio/candidate_02_sample_03.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/02_major_ii_v_turnaround_seed_2329/audio/candidate_01_sample_07.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/02_major_ii_v_turnaround_seed_2329/audio/candidate_02_sample_06.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/03_dominant_cycle_seed_2358/audio/candidate_01_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/03_dominant_cycle_seed_2358/audio/candidate_02_sample_03.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/04_rhythm_turnaround_seed_2387/audio/candidate_01_sample_03.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/packages/04_rhythm_turnaround_seed_2387/audio/candidate_02_sample_09.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary

- repaired 설정 기준 broader sampling repeatability audit 기록
- 4개 progression case, 총 40개 샘플 검증
- strict `40 / 40`, grammar `40 / 40`, min case strict rate `1.0000`
- selected MIDI `8`, rendered WAV `8`
- README 최신 evidence 및 결과 파일 경로 갱신

## Context

- #1342 handoff reproducibility audit 결과: reproducible handoff `true`, checksum mismatch `0`
- #1332 larger sample sweep 결과: strict `24 / 24`
- 더 넓은 seed 표본에서 repaired 설정 repeatability 확인 필요
- 청취 입력 전 musical quality claim 제외

## Validation

- `.venv/bin/python scripts/run_music_transformer_solo_yield_sweep.py --run_id issue_1344_broader_repaired_sampling_repeatability --doc_path docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md --sample_count 10 --bars 4 --duration_mode fill --note_groups_per_bar 9 --seed_start 2300 --seed_stride 29 --top_n 2 --min_cases 4 --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human audio preference: not proven
- stable jazz solo quality: not proven
- artist-level long solo generation: not proven

Closes #1344