### PR TITLE
Stage B MIDI-to-solo broader repaired listening review package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- broader repaired sampling audit: strict `40 / 40`, grammar-valid `40 / 40`
+- broader repaired listening package: MIDI `8`, WAV `8`, next `listening_input_guard`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -202,6 +202,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - broader repaired sampling repeatability: strict `40 / 40`, grammar-valid `40 / 40`, min case strict rate `1.0000`
 - broader repaired sampling package: selected MIDI `8`, rendered WAV `8`, musical quality claim `false`
 - next boundary: `music_transformer_solo_yield_candidate_listening_review`
+- broader repaired listening package: MIDI `8`, WAV `8`, review input template ready `true`
+- broader repaired listening package claim boundary: validated listening input `false`, musical quality claim `false`
+- next boundary: `music_transformer_solo_yield_listening_input_guard`
 
 ## 결과 파일
 
@@ -249,6 +252,10 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/solo_yield_sweep_report.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/solo_yield_sweep_report.json`
 - `docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_SAMPLING_REPEATABILITY_AUDIT_2026-06-11.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/listening_review_package.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/listening_review_package.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/listening_review_input_template.json`
+- `docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_LISTENING_PACKAGE_2026-06-11.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`

--- a/docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_LISTENING_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_LISTENING_PACKAGE_2026-06-11.md
@@ -1,0 +1,37 @@
+# Music Transformer Solo Yield Listening Review Package
+
+## Summary
+
+- source strict yield: `40` / `40`
+- source strict yield rate: `1.0000`
+- source rendered audio files: `8`
+- review candidate count: `8`
+- MIDI files copied: `8`
+- WAV files copied: `8`
+- validated listening input present: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_listening_input_guard`
+
+## Candidates
+
+| review | case | chords | score | notes | dead air | WAV | MIDI |
+|---:|---|---|---:|---:|---:|---|---|
+| 1 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 233.548 | 30 | 0.7241 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/audio/candidate_01_minor_backdoor_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/midi/candidate_01_minor_backdoor_rank_01.mid` |
+| 2 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 233.365 | 33 | 0.6250 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/audio/candidate_02_minor_backdoor_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/midi/candidate_02_minor_backdoor_rank_02.mid` |
+| 3 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 233.551 | 28 | 0.6296 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/audio/candidate_03_major_ii_v_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/midi/candidate_03_major_ii_v_turnaround_rank_01.mid` |
+| 4 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 233.134 | 28 | 0.6667 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/midi/candidate_04_major_ii_v_turnaround_rank_02.mid` |
+| 5 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 233.777 | 31 | 0.6333 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/audio/candidate_05_dominant_cycle_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/midi/candidate_05_dominant_cycle_rank_01.mid` |
+| 6 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 233.689 | 30 | 0.6897 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/audio/candidate_06_dominant_cycle_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/midi/candidate_06_dominant_cycle_rank_02.mid` |
+| 7 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 234.104 | 30 | 0.6552 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/audio/candidate_07_rhythm_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/midi/candidate_07_rhythm_turnaround_rank_01.mid` |
+| 8 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 233.744 | 29 | 0.6429 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/audio/candidate_08_rhythm_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/midi/candidate_08_rhythm_turnaround_rank_02.mid` |
+
+## Review Input
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/listening_review_input_template.json`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary

- #1344 broader repaired sampling audit 결과 기반 listening review package 생성
- MIDI 후보 `8`, WAV 후보 `8`, review input template 경로 기록
- next boundary: `music_transformer_solo_yield_listening_input_guard`
- README 최신 evidence 및 결과 파일 경로 갱신

## Context

- #1344 broader repaired sampling repeatability audit 결과: strict `40 / 40`, grammar `40 / 40`, min case strict rate `1.0000`
- selected MIDI `8`, rendered WAV `8`
- 청취 입력 전 musical quality claim 제외

## Validation

- `.venv/bin/python scripts/build_music_transformer_solo_yield_listening_package.py --sweep_report outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/solo_yield_sweep_report.json --run_id issue_1346_broader_repaired_listening_package --doc_path docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_LISTENING_PACKAGE_2026-06-11.md --max_candidates 8 --min_candidates 8 --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human audio preference: not proven
- stable jazz solo quality: not proven
- artist-level long solo generation: not proven

Closes #1346