### PR TITLE
Stage B MIDI-to-solo broader repaired handoff reproducibility audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- broader repaired final handoff: MIDI `8`, WAV `8`, checksum mismatch `0`
+- broader repaired handoff audit: reproducible `true`, checksum mismatch `0`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -214,6 +214,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - broader repaired final review handoff: MIDI `8`, WAV `8`, selected objective candidates `4`
 - broader repaired final handoff validation: missing file `0`, checksum mismatch `0`, musical quality claim `false`
 - next boundary: `music_transformer_solo_yield_broader_repaired_listening_review`
+- broader repaired handoff reproducibility audit: reproducible `true`, missing MIDI/WAV `0 / 0`, checksum mismatch `0 / 0`
+- broader repaired handoff audit claim boundary: musical quality claim `false`, stable jazz solo quality `not_proven`
+- next boundary: `music_transformer_solo_yield_final_readme_evidence_refresh`
 
 ## 결과 파일
 
@@ -274,6 +277,9 @@ raw model generation은 note grammar가 자주 깨졌다.
 - `outputs/music_transformer_finetune_mvp/solo_yield_broader_repaired_final_handoff/issue_1352_broader_repaired_final_handoff/broader_repaired_final_review_handoff.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_broader_repaired_final_handoff/issue_1352_broader_repaired_final_handoff/broader_repaired_final_review_handoff.json`
 - `docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_FINAL_REVIEW_HANDOFF_2026-06-11.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_broader_repaired_handoff_audit/issue_1354_broader_repaired_handoff_audit/broader_repaired_handoff_reproducibility_audit.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_broader_repaired_handoff_audit/issue_1354_broader_repaired_handoff_audit/broader_repaired_handoff_reproducibility_audit.json`
+- `docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.md`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_package.json`
 - `outputs/music_transformer_finetune_mvp/solo_yield_interval_contour_aftercare_listening_review/issue_1308_interval_contour_listening_package/listening_review_input_template.json`

--- a/docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md
@@ -1,0 +1,65 @@
+# Music Transformer Solo Yield Broader Repaired Handoff Reproducibility Audit
+
+## Summary
+
+- boundary: `music_transformer_solo_yield_broader_repaired_handoff_reproducibility_audit`
+- candidate count: `8`
+- selected objective candidates: `4`
+- missing MIDI/WAV: `0` / `0`
+- checksum mismatch MIDI/WAV: `0` / `0`
+- duration range seconds: `10.6957` - `10.7392`
+- sample rates: `44100`
+- reproducible handoff: `true`
+- selected next target: `final_readme_evidence_refresh`
+- next boundary: `music_transformer_solo_yield_final_readme_evidence_refresh`
+- musical quality claimed: `false`
+
+## Candidate File Audit
+
+- candidate `1` / `minor_backdoor`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7349`
+  - selected by objective: `false`
+- candidate `2` / `minor_backdoor`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.6957`
+  - selected by objective: `false`
+- candidate `3` / `major_ii_v_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7349`
+  - selected by objective: `false`
+- candidate `4` / `major_ii_v_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7378`
+  - selected by objective: `false`
+- candidate `5` / `dominant_cycle`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7102`
+  - selected by objective: `true`
+- candidate `6` / `dominant_cycle`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7088`
+  - selected by objective: `true`
+- candidate `7` / `rhythm_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7392`
+  - selected by objective: `true`
+- candidate `8` / `rhythm_turnaround`
+  - MIDI exists/checksum: `true` / `true`
+  - WAV exists/checksum: `true` / `true`
+  - duration seconds: `10.7102`
+  - selected by objective: `true`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/audit_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py
+++ b/scripts/audit_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py
@@ -84,11 +84,16 @@ def validate_source_handoff(
     *,
     expected_candidate_count: int,
     expected_selected_count: int,
+    expected_handoff_schema_version: str,
 ) -> dict[str, Any]:
-    if str(handoff_report.get("schema_version") or "") != HANDOFF_SCHEMA_VERSION:
+    if str(handoff_report.get("schema_version") or "") != expected_handoff_schema_version:
         raise SoloYieldLargerSampleHandoffReproducibilityAuditError("handoff schema required")
     try:
-        summary = validate_handoff_report(handoff_report, require_no_quality_claim=True)
+        summary = validate_handoff_report(
+            handoff_report,
+            require_no_quality_claim=True,
+            expected_schema_version=expected_handoff_schema_version,
+        )
     except ValueError as exc:
         raise SoloYieldLargerSampleHandoffReproducibilityAuditError(str(exc)) from exc
     if _int(summary.get("candidate_count")) != int(expected_candidate_count):
@@ -176,12 +181,21 @@ def build_reproducibility_audit(
     output_dir: Path,
     expected_candidate_count: int,
     expected_selected_count: int,
+    expected_handoff_schema_version: str = HANDOFF_SCHEMA_VERSION,
+    schema_version: str = SCHEMA_VERSION,
+    boundary: str = BOUNDARY,
+    next_boundary: str = NEXT_BOUNDARY,
+    output_basename: str = "larger_sample_handoff_reproducibility_audit",
+    title: str = "Music Transformer Solo Yield Larger Sample Handoff Reproducibility Audit",
+    selected_next_target: str = "broader_repaired_sampling_repeatability_audit",
+    decision_reason: str = "larger-sample handoff is reproducible; next objective-only check is broader repaired sampling repeatability",
 ) -> dict[str, Any]:
     output_dir.mkdir(parents=True, exist_ok=True)
     source_summary = validate_source_handoff(
         handoff_report,
         expected_candidate_count=int(expected_candidate_count),
         expected_selected_count=int(expected_selected_count),
+        expected_handoff_schema_version=expected_handoff_schema_version,
     )
     _require_no_quality_claim(handoff_report)
     candidate_rows = [_dict(row) for row in _list(handoff_report.get("candidate_handoff"))]
@@ -194,10 +208,11 @@ def build_reproducibility_audit(
             f"handoff reproducibility audit failed: {aggregate}"
         )
     report = {
-        "schema_version": SCHEMA_VERSION,
+        "schema_version": schema_version,
         "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
         "output_dir": str(output_dir),
-        "boundary": BOUNDARY,
+        "boundary": boundary,
+        "title": title,
         "source_handoff": {
             "schema_version": handoff_report.get("schema_version"),
             "output_dir": handoff_report.get("output_dir"),
@@ -226,11 +241,11 @@ def build_reproducibility_audit(
             "production_ready_claimed": False,
         },
         "decision": {
-            "current_boundary": BOUNDARY,
-            "selected_next_target": "broader_repaired_sampling_repeatability_audit",
-            "next_boundary": NEXT_BOUNDARY,
+            "current_boundary": boundary,
+            "selected_next_target": selected_next_target,
+            "next_boundary": next_boundary,
             "critical_user_input_required": False,
-            "reason": "larger-sample handoff is reproducible; next objective-only check is broader repaired sampling repeatability",
+            "reason": decision_reason,
         },
         "not_proven": [
             "human_audio_preference",
@@ -239,17 +254,26 @@ def build_reproducibility_audit(
             "production_ready_improviser",
         ],
     }
-    write_json(output_dir / "larger_sample_handoff_reproducibility_audit.json", report)
+    write_json(output_dir / f"{output_basename}.json", report)
     write_json(
-        output_dir / "larger_sample_handoff_reproducibility_audit_summary.json",
-        validate_report(report, require_no_quality_claim=True),
+        output_dir / f"{output_basename}_summary.json",
+        validate_report(
+            report,
+            require_no_quality_claim=True,
+            expected_schema_version=schema_version,
+        ),
     )
-    write_text(output_dir / "larger_sample_handoff_reproducibility_audit.md", markdown_report(report))
+    write_text(output_dir / f"{output_basename}.md", markdown_report(report))
     return report
 
 
-def validate_report(report: dict[str, Any], *, require_no_quality_claim: bool) -> dict[str, Any]:
-    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+def validate_report(
+    report: dict[str, Any],
+    *,
+    require_no_quality_claim: bool,
+    expected_schema_version: str = SCHEMA_VERSION,
+) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != expected_schema_version:
         raise SoloYieldLargerSampleHandoffReproducibilityAuditError("schema version mismatch")
     if require_no_quality_claim:
         _require_no_quality_claim(report)
@@ -281,7 +305,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     readiness = report["readiness"]
     decision = report["decision"]
     lines = [
-        "# Music Transformer Solo Yield Larger Sample Handoff Reproducibility Audit",
+        f"# {report.get('title') or 'Music Transformer Solo Yield Handoff Reproducibility Audit'}",
         "",
         "## Summary",
         "",
@@ -335,6 +359,33 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--expected_candidate_count", type=int, default=8)
     parser.add_argument("--expected_selected_count", type=int, default=4)
     parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_handoff_schema_version", type=str, default=HANDOFF_SCHEMA_VERSION)
+    parser.add_argument("--schema_version", type=str, default=SCHEMA_VERSION)
+    parser.add_argument("--boundary", type=str, default=BOUNDARY)
+    parser.add_argument("--next_boundary", type=str, default=NEXT_BOUNDARY)
+    parser.add_argument(
+        "--output_basename",
+        type=str,
+        default="larger_sample_handoff_reproducibility_audit",
+    )
+    parser.add_argument(
+        "--title",
+        type=str,
+        default="Music Transformer Solo Yield Larger Sample Handoff Reproducibility Audit",
+    )
+    parser.add_argument(
+        "--selected_next_target",
+        type=str,
+        default="broader_repaired_sampling_repeatability_audit",
+    )
+    parser.add_argument(
+        "--decision_reason",
+        type=str,
+        default=(
+            "larger-sample handoff is reproducible; next objective-only check is "
+            "broader repaired sampling repeatability"
+        ),
+    )
     parser.add_argument("--require_no_quality_claim", action="store_true")
     return parser
 
@@ -348,8 +399,20 @@ def main() -> int:
         output_dir=output_dir,
         expected_candidate_count=int(args.expected_candidate_count),
         expected_selected_count=int(args.expected_selected_count),
+        expected_handoff_schema_version=str(args.expected_handoff_schema_version),
+        schema_version=str(args.schema_version),
+        boundary=str(args.boundary),
+        next_boundary=str(args.next_boundary),
+        output_basename=str(args.output_basename),
+        title=str(args.title),
+        selected_next_target=str(args.selected_next_target),
+        decision_reason=str(args.decision_reason),
     )
-    summary = validate_report(report, require_no_quality_claim=bool(args.require_no_quality_claim))
+    summary = validate_report(
+        report,
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+        expected_schema_version=str(args.schema_version),
+    )
     if args.doc_path:
         write_text(Path(args.doc_path), markdown_report(report))
     print(json.dumps(summary, ensure_ascii=True, indent=2))

--- a/tests/test_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py
+++ b/tests/test_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py
@@ -127,6 +127,42 @@ class MusicTransformerSoloYieldLargerSampleHandoffReproducibilityTest(unittest.T
                     expected_selected_count=1,
                 )
 
+    def test_supports_custom_schema_boundary_and_output_basename(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            custom_handoff_schema = "custom_handoff_v1"
+            custom_schema = "custom_handoff_audit_v1"
+            custom_boundary = "custom_handoff_audit"
+            custom_next = "custom_next_boundary"
+            source = handoff_report(root)
+            source["schema_version"] = custom_handoff_schema
+            report = build_reproducibility_audit(
+                source,
+                output_dir=root / "out",
+                expected_candidate_count=1,
+                expected_selected_count=1,
+                expected_handoff_schema_version=custom_handoff_schema,
+                schema_version=custom_schema,
+                boundary=custom_boundary,
+                next_boundary=custom_next,
+                output_basename="custom_handoff_audit",
+                title="Custom Handoff Audit",
+                selected_next_target="custom_target",
+            )
+            summary = validate_report(
+                report,
+                require_no_quality_claim=True,
+                expected_schema_version=custom_schema,
+            )
+
+            self.assertEqual(summary["schema_version"], custom_schema)
+            self.assertEqual(summary["boundary"], custom_boundary)
+            self.assertEqual(summary["selected_next_target"], "custom_target")
+            self.assertEqual(summary["next_boundary"], custom_next)
+            self.assertTrue((root / "out" / "custom_handoff_audit.json").exists())
+            self.assertTrue((root / "out" / "custom_handoff_audit_summary.json").exists())
+            self.assertTrue((root / "out" / "custom_handoff_audit.md").exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- handoff reproducibility audit script expected schema/boundary/output basename 파라미터화
- broader repaired handoff reproducibility audit 생성
- MIDI/WAV 후보 `8 / 8` 존재 및 checksum 재검증
- missing MIDI/WAV `0 / 0`, checksum mismatch `0 / 0`
- reproducible handoff `true`
- README 최신 evidence 및 audit 결과 경로 갱신

## Context

- #1352 broader final handoff 결과: MIDI `8`, WAV `8`, selected objective candidates `4`
- 기존 audit script는 larger sample handoff schema에 고정
- broader repaired handoff schema/output basename 기준 audit 필요

## Validation

- `.venv/bin/python -m unittest tests.test_music_transformer_solo_yield_larger_sample_handoff_reproducibility`
- `.venv/bin/python scripts/audit_music_transformer_solo_yield_larger_sample_handoff_reproducibility.py --handoff_report outputs/music_transformer_finetune_mvp/solo_yield_broader_repaired_final_handoff/issue_1352_broader_repaired_final_handoff/broader_repaired_final_review_handoff.json --output_root outputs/music_transformer_finetune_mvp/solo_yield_broader_repaired_handoff_audit --run_id issue_1354_broader_repaired_handoff_audit --expected_candidate_count 8 --expected_selected_count 4 --expected_handoff_schema_version music_transformer_solo_yield_broader_repaired_final_review_handoff_v1 --schema_version music_transformer_solo_yield_broader_repaired_handoff_reproducibility_audit_v1 --boundary music_transformer_solo_yield_broader_repaired_handoff_reproducibility_audit --next_boundary music_transformer_solo_yield_final_readme_evidence_refresh --output_basename broader_repaired_handoff_reproducibility_audit --title "Music Transformer Solo Yield Broader Repaired Handoff Reproducibility Audit" --selected_next_target final_readme_evidence_refresh --decision_reason "broader repaired handoff is reproducible; next objective-only step is final README evidence refresh" --doc_path docs/STAGE_B_MIDI_TO_SOLO_BROADER_REPAIRED_HANDOFF_REPRODUCIBILITY_AUDIT_2026-06-11.md --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human audio preference: not proven
- stable jazz solo quality: not proven
- artist-level long solo generation: not proven

Closes #1354