### PR TITLE
Stage B MIDI-to-solo final status audit evidence refresh

### DIFF
--- a/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_EVIDENCE_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_EVIDENCE_REFRESH_2026-06-11.md
@@ -1,0 +1,39 @@
+# Music Transformer Solo Yield Final Status Audit
+
+## Summary
+
+- technical MVP evidence ready: `true`
+- checkpoint generation used: `true`
+- constrained decoding used: `true`
+- case count: `4`
+- sample count: `40`
+- strict yield: `40` / `40`
+- grammar yield: `40` / `40`
+- strict yield rate: `1.0000`
+- min case strict yield rate: `1.0000`
+- rendered WAV files: `8`
+- repaired candidate count: `8`
+- selected objective candidates: `4`
+- objective dead-air range: `0.6250` - `0.7241`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- final review handoff present: `true`
+- final review handoff ready: `true`
+- final handoff MIDI/WAV: `8` / `8`
+- final handoff missing files: `0`
+- final handoff checksum mismatch: `0`
+- handoff reproducibility audit present: `true`
+- handoff reproducibility audit completed: `true`
+- reproducible handoff: `true`
+- handoff missing MIDI/WAV: `0` / `0`
+- handoff checksum mismatch MIDI/WAV: `0` / `0`
+- musical quality claimed: `false`
+- raw artifact upload required: `false`
+- next boundary: `music_transformer_solo_yield_readme_final_evidence_refresh`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/audit_music_transformer_solo_yield_final_status.py
+++ b/scripts/audit_music_transformer_solo_yield_final_status.py
@@ -67,10 +67,21 @@ def build_audit_report(
     repaired_package: dict[str, Any],
     repaired_guard: dict[str, Any],
     repaired_objective: dict[str, Any],
+    final_handoff: dict[str, Any] | None = None,
+    handoff_audit: dict[str, Any] | None = None,
     output_dir: Path,
 ) -> dict[str, Any]:
     output_dir.mkdir(parents=True, exist_ok=True)
-    _require_no_quality_claim(repair_sweep, repaired_package, repaired_guard, repaired_objective)
+    final_handoff = final_handoff or {}
+    handoff_audit = handoff_audit or {}
+    _require_no_quality_claim(
+        repair_sweep,
+        repaired_package,
+        repaired_guard,
+        repaired_objective,
+        final_handoff,
+        handoff_audit,
+    )
 
     sweep_aggregate = _dict(repair_sweep.get("aggregate"))
     sweep_readiness = _dict(repair_sweep.get("readiness"))
@@ -79,6 +90,10 @@ def build_audit_report(
     guard_validation = _dict(repaired_guard.get("input_validation"))
     objective_readiness = _dict(repaired_objective.get("readiness"))
     objective_summary = _dict(repaired_objective.get("objective_summary"))
+    final_handoff_readiness = _dict(final_handoff.get("readiness"))
+    final_handoff_aggregate = _dict(final_handoff.get("aggregate"))
+    handoff_audit_readiness = _dict(handoff_audit.get("readiness"))
+    handoff_audit_aggregate = _dict(handoff_audit.get("aggregate"))
 
     repaired_candidate_count = _int(repaired_package.get("candidate_count"))
     midi_count = _int(package_readiness.get("candidate_midi_files_copied"))
@@ -87,6 +102,49 @@ def build_audit_report(
     strict_count = _int(sweep_aggregate.get("strict_valid_sample_count"))
     sample_count = _int(sweep_aggregate.get("sample_count"))
     grammar_count = _int(sweep_aggregate.get("grammar_gate_sample_count"))
+    final_handoff_present = bool(final_handoff)
+    final_handoff_candidate_count = _int(final_handoff_aggregate.get("candidate_count"))
+    final_handoff_midi_count = _int(final_handoff_aggregate.get("midi_count"))
+    final_handoff_wav_count = _int(final_handoff_aggregate.get("wav_count"))
+    final_handoff_missing_count = _int(final_handoff_aggregate.get("missing_file_count"))
+    final_handoff_checksum_mismatch_count = _int(
+        final_handoff_aggregate.get("checksum_mismatch_count")
+    )
+    final_handoff_ready = bool(final_handoff_readiness.get("final_review_handoff_ready", False))
+    final_handoff_verified = (not final_handoff_present) or (
+        final_handoff_ready
+        and final_handoff_candidate_count >= 1
+        and final_handoff_midi_count == final_handoff_candidate_count
+        and final_handoff_wav_count == final_handoff_candidate_count
+        and final_handoff_missing_count == 0
+        and final_handoff_checksum_mismatch_count == 0
+    )
+    handoff_audit_present = bool(handoff_audit)
+    handoff_reproducibility_completed = bool(
+        handoff_audit_readiness.get("reproducibility_audit_completed", False)
+    )
+    reproducible_handoff = bool(
+        handoff_audit_readiness.get(
+            "reproducible_handoff",
+            handoff_audit_aggregate.get("reproducible_handoff", False),
+        )
+    )
+    handoff_missing_midi_count = _int(handoff_audit_aggregate.get("missing_midi_count"))
+    handoff_missing_wav_count = _int(handoff_audit_aggregate.get("missing_wav_count"))
+    handoff_midi_checksum_mismatch_count = _int(
+        handoff_audit_aggregate.get("midi_checksum_mismatch_count")
+    )
+    handoff_wav_checksum_mismatch_count = _int(
+        handoff_audit_aggregate.get("wav_checksum_mismatch_count")
+    )
+    handoff_audit_verified = (not handoff_audit_present) or (
+        handoff_reproducibility_completed
+        and reproducible_handoff
+        and handoff_missing_midi_count == 0
+        and handoff_missing_wav_count == 0
+        and handoff_midi_checksum_mismatch_count == 0
+        and handoff_wav_checksum_mismatch_count == 0
+    )
 
     technical_ready = bool(
         strict_count > 0
@@ -96,6 +154,8 @@ def build_audit_report(
         and wav_count == repaired_candidate_count
         and selected_objective_count >= 1
         and not bool(guard_readiness.get("preference_fill_allowed", True))
+        and final_handoff_verified
+        and handoff_audit_verified
     )
 
     report = {
@@ -107,6 +167,8 @@ def build_audit_report(
             "repaired_package": repaired_package.get("output_dir"),
             "repaired_guard": repaired_guard.get("output_dir"),
             "repaired_objective": repaired_objective.get("output_dir"),
+            "final_handoff": final_handoff.get("output_dir"),
+            "handoff_audit": handoff_audit.get("output_dir"),
         },
         "final_status": {
             "technical_mvp_evidence_ready": technical_ready,
@@ -131,6 +193,20 @@ def build_audit_report(
                 guard_validation.get("validated_listening_input_present", False)
             ),
             "preference_fill_allowed": bool(guard_readiness.get("preference_fill_allowed", True)),
+            "final_review_handoff_present": final_handoff_present,
+            "final_review_handoff_ready": final_handoff_ready,
+            "final_handoff_candidate_count": final_handoff_candidate_count,
+            "final_handoff_midi_count": final_handoff_midi_count,
+            "final_handoff_wav_count": final_handoff_wav_count,
+            "final_handoff_missing_file_count": final_handoff_missing_count,
+            "final_handoff_checksum_mismatch_count": final_handoff_checksum_mismatch_count,
+            "handoff_reproducibility_audit_present": handoff_audit_present,
+            "handoff_reproducibility_audit_completed": handoff_reproducibility_completed,
+            "reproducible_handoff": reproducible_handoff,
+            "handoff_missing_midi_count": handoff_missing_midi_count,
+            "handoff_missing_wav_count": handoff_missing_wav_count,
+            "handoff_midi_checksum_mismatch_count": handoff_midi_checksum_mismatch_count,
+            "handoff_wav_checksum_mismatch_count": handoff_wav_checksum_mismatch_count,
             "musical_quality_claimed": False,
             "artist_style_claimed": False,
             "production_ready_claimed": False,
@@ -193,6 +269,30 @@ def validate_audit_report(report: dict[str, Any]) -> dict[str, Any]:
         "selected_objective_candidate_count": _int(final_status.get("selected_objective_candidate_count")),
         "validated_listening_input_present": bool(final_status.get("validated_listening_input_present", True)),
         "preference_fill_allowed": bool(final_status.get("preference_fill_allowed", True)),
+        "final_review_handoff_present": bool(final_status.get("final_review_handoff_present", False)),
+        "final_review_handoff_ready": bool(final_status.get("final_review_handoff_ready", False)),
+        "final_handoff_candidate_count": _int(final_status.get("final_handoff_candidate_count")),
+        "final_handoff_midi_count": _int(final_status.get("final_handoff_midi_count")),
+        "final_handoff_wav_count": _int(final_status.get("final_handoff_wav_count")),
+        "final_handoff_missing_file_count": _int(final_status.get("final_handoff_missing_file_count")),
+        "final_handoff_checksum_mismatch_count": _int(
+            final_status.get("final_handoff_checksum_mismatch_count")
+        ),
+        "handoff_reproducibility_audit_present": bool(
+            final_status.get("handoff_reproducibility_audit_present", False)
+        ),
+        "handoff_reproducibility_audit_completed": bool(
+            final_status.get("handoff_reproducibility_audit_completed", False)
+        ),
+        "reproducible_handoff": bool(final_status.get("reproducible_handoff", False)),
+        "handoff_missing_midi_count": _int(final_status.get("handoff_missing_midi_count")),
+        "handoff_missing_wav_count": _int(final_status.get("handoff_missing_wav_count")),
+        "handoff_midi_checksum_mismatch_count": _int(
+            final_status.get("handoff_midi_checksum_mismatch_count")
+        ),
+        "handoff_wav_checksum_mismatch_count": _int(
+            final_status.get("handoff_wav_checksum_mismatch_count")
+        ),
         "musical_quality_claimed": bool(final_status.get("musical_quality_claimed", True)),
         "next_boundary": str(_dict(report.get("decision")).get("next_boundary") or ""),
     }
@@ -221,6 +321,16 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective dead-air range: `{float(status['objective_dead_air_min']):.4f}` - `{float(status['objective_dead_air_max']):.4f}`",
         f"- validated listening input present: `{_bool_token(status['validated_listening_input_present'])}`",
         f"- preference fill allowed: `{_bool_token(status['preference_fill_allowed'])}`",
+        f"- final review handoff present: `{_bool_token(status['final_review_handoff_present'])}`",
+        f"- final review handoff ready: `{_bool_token(status['final_review_handoff_ready'])}`",
+        f"- final handoff MIDI/WAV: `{status['final_handoff_midi_count']}` / `{status['final_handoff_wav_count']}`",
+        f"- final handoff missing files: `{status['final_handoff_missing_file_count']}`",
+        f"- final handoff checksum mismatch: `{status['final_handoff_checksum_mismatch_count']}`",
+        f"- handoff reproducibility audit present: `{_bool_token(status['handoff_reproducibility_audit_present'])}`",
+        f"- handoff reproducibility audit completed: `{_bool_token(status['handoff_reproducibility_audit_completed'])}`",
+        f"- reproducible handoff: `{_bool_token(status['reproducible_handoff'])}`",
+        f"- handoff missing MIDI/WAV: `{status['handoff_missing_midi_count']}` / `{status['handoff_missing_wav_count']}`",
+        f"- handoff checksum mismatch MIDI/WAV: `{status['handoff_midi_checksum_mismatch_count']}` / `{status['handoff_wav_checksum_mismatch_count']}`",
         f"- musical quality claimed: `{_bool_token(status['musical_quality_claimed'])}`",
         f"- raw artifact upload required: `{_bool_token(status['raw_artifact_upload_required'])}`",
         f"- next boundary: `{decision['next_boundary']}`",
@@ -267,6 +377,8 @@ def build_parser() -> argparse.ArgumentParser:
             "issue_1254_4bar_repaired_objective_next_decision/objective_next_decision.json"
         ),
     )
+    parser.add_argument("--final_handoff_report", type=str, default="")
+    parser.add_argument("--handoff_audit_report", type=str, default="")
     parser.add_argument(
         "--output_root",
         type=str,
@@ -286,6 +398,8 @@ def main() -> int:
         repaired_package=read_json(Path(args.repaired_package_report)),
         repaired_guard=read_json(Path(args.repaired_guard_report)),
         repaired_objective=read_json(Path(args.repaired_objective_report)),
+        final_handoff=read_json(Path(args.final_handoff_report)) if args.final_handoff_report else None,
+        handoff_audit=read_json(Path(args.handoff_audit_report)) if args.handoff_audit_report else None,
         output_dir=output_dir,
     )
     summary = validate_audit_report(report)

--- a/tests/test_music_transformer_solo_yield_final_status_audit.py
+++ b/tests/test_music_transformer_solo_yield_final_status_audit.py
@@ -83,6 +83,54 @@ def repaired_objective() -> dict:
     }
 
 
+def final_handoff(*, missing_file_count: int = 0) -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_broader_repaired_final_review_handoff_v1",
+        "output_dir": "outputs/final_handoff",
+        "aggregate": {
+            "candidate_count": 8,
+            "midi_count": 8,
+            "wav_count": 8,
+            "selected_objective_candidate_count": 4,
+            "missing_file_count": missing_file_count,
+            "checksum_mismatch_count": 0,
+        },
+        "readiness": {
+            "final_review_handoff_ready": True,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def handoff_audit(*, reproducible: bool = True) -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_broader_repaired_handoff_reproducibility_audit_v1",
+        "output_dir": "outputs/handoff_audit",
+        "aggregate": {
+            "candidate_count": 8,
+            "selected_objective_candidate_count": 4,
+            "missing_midi_count": 0,
+            "missing_wav_count": 0,
+            "midi_checksum_mismatch_count": 0,
+            "wav_checksum_mismatch_count": 0,
+            "reproducible_handoff": reproducible,
+        },
+        "readiness": {
+            "reproducibility_audit_completed": True,
+            "reproducible_handoff": reproducible,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
 class MusicTransformerSoloYieldFinalStatusAuditTest(unittest.TestCase):
     def test_builds_final_status_audit_without_quality_claim(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -105,6 +153,67 @@ class MusicTransformerSoloYieldFinalStatusAuditTest(unittest.TestCase):
         self.assertFalse(summary["preference_fill_allowed"])
         self.assertFalse(summary["musical_quality_claimed"])
         self.assertEqual(summary["next_boundary"], "music_transformer_solo_yield_readme_final_evidence_refresh")
+
+    def test_includes_final_handoff_reproducibility_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_audit_report(
+                repair_sweep=repair_sweep(),
+                repaired_package=repaired_package(),
+                repaired_guard=repaired_guard(),
+                repaired_objective=repaired_objective(),
+                final_handoff=final_handoff(),
+                handoff_audit=handoff_audit(),
+                output_dir=Path(temp_dir) / "audit",
+            )
+        summary = validate_audit_report(report)
+
+        self.assertTrue(summary["technical_mvp_evidence_ready"])
+        self.assertTrue(summary["final_review_handoff_present"])
+        self.assertTrue(summary["final_review_handoff_ready"])
+        self.assertEqual(summary["final_handoff_candidate_count"], 8)
+        self.assertEqual(summary["final_handoff_midi_count"], 8)
+        self.assertEqual(summary["final_handoff_wav_count"], 8)
+        self.assertEqual(summary["final_handoff_missing_file_count"], 0)
+        self.assertEqual(summary["final_handoff_checksum_mismatch_count"], 0)
+        self.assertTrue(summary["handoff_reproducibility_audit_present"])
+        self.assertTrue(summary["handoff_reproducibility_audit_completed"])
+        self.assertTrue(summary["reproducible_handoff"])
+        self.assertEqual(summary["handoff_missing_midi_count"], 0)
+        self.assertEqual(summary["handoff_missing_wav_count"], 0)
+        self.assertEqual(summary["handoff_midi_checksum_mismatch_count"], 0)
+        self.assertEqual(summary["handoff_wav_checksum_mismatch_count"], 0)
+
+    def test_handoff_mismatch_keeps_technical_ready_false(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_audit_report(
+                repair_sweep=repair_sweep(),
+                repaired_package=repaired_package(),
+                repaired_guard=repaired_guard(),
+                repaired_objective=repaired_objective(),
+                final_handoff=final_handoff(missing_file_count=1),
+                handoff_audit=handoff_audit(),
+                output_dir=Path(temp_dir) / "audit",
+            )
+        summary = validate_audit_report(report)
+
+        self.assertFalse(summary["technical_mvp_evidence_ready"])
+        self.assertEqual(summary["final_handoff_missing_file_count"], 1)
+
+    def test_non_reproducible_handoff_keeps_technical_ready_false(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_audit_report(
+                repair_sweep=repair_sweep(),
+                repaired_package=repaired_package(),
+                repaired_guard=repaired_guard(),
+                repaired_objective=repaired_objective(),
+                final_handoff=final_handoff(),
+                handoff_audit=handoff_audit(reproducible=False),
+                output_dir=Path(temp_dir) / "audit",
+            )
+        summary = validate_audit_report(report)
+
+        self.assertFalse(summary["technical_mvp_evidence_ready"])
+        self.assertFalse(summary["reproducible_handoff"])
 
     def test_rejects_quality_claim_in_source_report(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- final status audit handoff evidence fields added
- final handoff readiness and reproducibility audit metrics included
- #1344/#1346/#1348/#1350/#1352/#1354 based final status audit document generated

## Context

- latest sampling audit: strict `40 / 40`, grammar-valid `40 / 40`
- latest listening package: MIDI `8`, WAV `8`
- final handoff: selected objective candidates `4`, missing file `0`, checksum mismatch `0`
- handoff audit: reproducible `true`, missing MIDI/WAV `0 / 0`, checksum mismatch MIDI/WAV `0 / 0`
- existing final status audit did not summarize #1352/#1354 handoff evidence

## Scope

- optional final handoff and handoff audit inputs added to final status audit script
- technical readiness now includes handoff verification when those inputs are provided
- summary and markdown output include handoff presence, readiness, reproducibility, missing, checksum metrics
- regression tests added for valid, missing-file, and non-reproducible handoff cases

## Validation

- `.venv/bin/python -m py_compile scripts/audit_music_transformer_solo_yield_final_status.py tests/test_music_transformer_solo_yield_final_status_audit.py`
- `.venv/bin/python -m unittest tests.test_music_transformer_solo_yield_final_status_audit`
- `.venv/bin/python scripts/audit_music_transformer_solo_yield_final_status.py --run_id issue_1360_final_status_audit_refresh --repair_sweep_report outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/solo_yield_sweep_report.json --repaired_package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/listening_review_package.json --repaired_guard_report outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1348_broader_repaired_input_guard/listening_input_guard.json --repaired_objective_report outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1350_broader_repaired_objective_next/objective_next_decision.json --final_handoff_report outputs/music_transformer_finetune_mvp/solo_yield_broader_repaired_final_handoff/issue_1352_broader_repaired_final_handoff/broader_repaired_final_review_handoff.json --handoff_audit_report outputs/music_transformer_finetune_mvp/solo_yield_broader_repaired_handoff_audit/issue_1354_broader_repaired_handoff_audit/broader_repaired_handoff_reproducibility_audit.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_EVIDENCE_REFRESH_2026-06-11.md`
- `rg -n --hidden "codex|Codex|CODEX|ChatGPT|Claude|assistant" scripts/audit_music_transformer_solo_yield_final_status.py tests/test_music_transformer_solo_yield_final_status_audit.py docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_EVIDENCE_REFRESH_2026-06-11.md`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- generated output directory remains local evidence, not raw artifact upload
- musical quality claim: `false`
- human listening preference input: `false`
- stable jazz solo quality: `not_proven`

Closes #1360