### PR TITLE
Stage B MIDI-to-solo current status final audit refresh

### DIFF
--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -19,9 +19,12 @@
 - latest broader final review handoff: Issue #1352, Stage B MIDI-to-solo broader repaired final review handoff
 - latest broader handoff reproducibility audit: Issue #1354, Stage B MIDI-to-solo broader repaired handoff reproducibility audit
 - latest README final evidence refresh: Issue #1356, Stage B MIDI-to-solo final README evidence refresh
-- current issue: Issue #1358, Stage B MIDI-to-solo current status evidence refresh
-- open issue queue after README final evidence refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo final status audit evidence refresh`
+- latest current status evidence refresh: Issue #1358, Stage B MIDI-to-solo current status evidence refresh
+- latest final status audit evidence refresh: Issue #1360, Stage B MIDI-to-solo final status audit evidence refresh
+- latest README final status audit refresh: Issue #1362, Stage B MIDI-to-solo README final status audit refresh
+- current issue: Issue #1364, Stage B MIDI-to-solo current status final audit refresh
+- open issue queue after README final status audit refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo post-final quality iteration decision refresh`
 
 현재 범위가 아닌 것:
 
@@ -45,7 +48,11 @@
 - broader repaired handoff audit reproducible: `true`
 - broader repaired handoff audit missing MIDI/WAV: `0 / 0`
 - broader repaired handoff audit checksum mismatch MIDI/WAV: `0 / 0`
-- README final evidence refresh 완료
+- final status audit evidence refresh: technical ready `true`, strict/grammar `40 / 40` / `40 / 40`
+- final status audit handoff evidence: MIDI/WAV `8 / 8`, reproducible `true`
+- final status audit handoff missing MIDI/WAV: `0 / 0`
+- final status audit handoff checksum mismatch MIDI/WAV: `0 / 0`
+- README final status audit refresh 완료
 - stable jazz solo quality: `not_proven`
 - human listening preference input: `false`
 - artist style claim: `false`


### PR DESCRIPTION
## Summary

- current status top handoff refreshed after final audit
- #1360/#1362 completion reflected
- next quality iteration boundary separated

## Context

- #1360 final status audit evidence refresh merged
- #1362 README final status audit refresh merged
- current status still listed #1358 as current issue and final status audit as next recommended issue
- latest evidence: strict/grammar `40 / 40` / `40 / 40`, handoff MIDI/WAV `8 / 8`, reproducible `true`

## Scope

- latest issue summary updated with #1360/#1362/#1364
- final status audit handoff evidence added to current quality boundary
- next recommended issue changed to post-final quality iteration decision refresh
- historical body retained

## Validation

- `rg -n --hidden "codex|Codex|CODEX|ChatGPT|Claude|assistant" docs/CURRENT_STATUS_AND_PLAN.md`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- historical plan body remains cumulative
- musical quality claim: `false`
- human listening preference input: `false`
- stable jazz solo quality: `not_proven`

Closes #1364