### PR TITLE
Stage B MIDI-to-solo dead-air density balance repair package

### DIFF
--- a/docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_DENSITY_REPAIR_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_DENSITY_REPAIR_PACKAGE_2026-06-11.md
@@ -1,0 +1,38 @@
+# Music Transformer Solo Yield Dead-Air Density Repair Package
+
+## Summary
+
+- candidate count: `8`
+- MIDI/WAV: `8` / `8`
+- source dead-air avg/max: `0.6583` / `0.7241`
+- repair dead-air avg/max: `0.5806` / `0.6207`
+- dead-air avg delta: `0.0777`
+- source/repair dead-air high count: `2` / `0`
+- dead-air high count delta: `2`
+- source direction avg: `0.5887`
+- repair direction avg: `0.4912`
+- source tension avg: `0.2500`
+- repair tension avg: `0.2326`
+- technical WAV render completed: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_dead_air_density_balance_repair_rubric_review`
+
+## Selected Candidates
+
+| idx | case | sample | notes | dead air | direction | tension | MIDI | WAV |
+|---:|---|---:|---:|---:|---:|---:|---|---|
+| 1 | `minor_backdoor` | 2 | 31 | 0.5333 | 0.4706 | 0.2222 | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/midi/candidate_01_minor_backdoor_sample_02.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/audio/candidate_01_minor_backdoor_sample_02.wav` |
+| 2 | `minor_backdoor` | 7 | 32 | 0.5806 | 0.5000 | 0.1389 | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/midi/candidate_02_minor_backdoor_sample_07.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/audio/candidate_02_minor_backdoor_sample_07.wav` |
+| 3 | `major_ii_v_turnaround` | 2 | 31 | 0.5667 | 0.4118 | 0.2222 | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/midi/candidate_03_major_ii_v_turnaround_sample_02.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/audio/candidate_03_major_ii_v_turnaround_sample_02.wav` |
+| 4 | `major_ii_v_turnaround` | 5 | 32 | 0.5806 | 0.4118 | 0.1667 | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/midi/candidate_04_major_ii_v_turnaround_sample_05.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/audio/candidate_04_major_ii_v_turnaround_sample_05.wav` |
+| 5 | `dominant_cycle` | 8 | 33 | 0.5625 | 0.5294 | 0.3056 | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/midi/candidate_05_dominant_cycle_sample_08.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/audio/candidate_05_dominant_cycle_sample_08.wav` |
+| 6 | `dominant_cycle` | 5 | 31 | 0.6000 | 0.4242 | 0.3333 | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/midi/candidate_06_dominant_cycle_sample_05.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/audio/candidate_06_dominant_cycle_sample_05.wav` |
+| 7 | `rhythm_turnaround` | 5 | 31 | 0.6000 | 0.6061 | 0.2778 | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/midi/candidate_07_rhythm_turnaround_sample_05.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/audio/candidate_07_rhythm_turnaround_sample_05.wav` |
+| 8 | `rhythm_turnaround` | 8 | 30 | 0.6207 | 0.5758 | 0.1944 | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/midi/candidate_08_rhythm_turnaround_sample_08.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair/issue_1370_dead_air_density_repair_package/audio/candidate_08_rhythm_turnaround_sample_08.wav` |
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `direction_tension_tradeoff_resolved`
+- `repair_listening_preference`

--- a/scripts/build_music_transformer_solo_yield_dead_air_density_repair_package.py
+++ b/scripts/build_music_transformer_solo_yield_dead_air_density_repair_package.py
@@ -1,0 +1,507 @@
+"""Build a dead-air/density balanced repair package from solo-yield probe samples."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
+    resolve_soundfont,
+    sha256_file,
+    wav_meta,
+)
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_dead_air_density_repair_package_v1"
+
+
+class SoloYieldDeadAirDensityRepairPackageError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def avg(values: Sequence[float]) -> float:
+    return float(mean(values)) if values else 0.0
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldDeadAirDensityRepairPackageError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _reject_quality_claim(*reports: dict[str, Any]) -> None:
+    claimed: list[str] = []
+    for index, report in enumerate(reports, start=1):
+        readiness = _dict(report.get("readiness"))
+        for key in ("musical_quality_claimed", "artist_style_claimed", "production_ready_claimed"):
+            if bool(readiness.get(key, False)):
+                claimed.append(f"report_{index}:{key}")
+    if claimed:
+        raise SoloYieldDeadAirDensityRepairPackageError(f"unexpected quality claim: {claimed}")
+
+
+def compact_probe_sample(case: dict[str, Any], sample: dict[str, Any]) -> dict[str, Any]:
+    metrics = _dict(sample.get("metrics"))
+    contour = _dict(sample.get("phrase_contour"))
+    rhythm = _dict(sample.get("rhythm_profile"))
+    pitch_roles = _dict(sample.get("pitch_roles"))
+    return {
+        "case_label": str(case.get("label") or ""),
+        "chords": str(case.get("chords") or ""),
+        "case_seed": _int(case.get("seed")),
+        "sample_index": _int(sample.get("sample_index")),
+        "sample_seed": _int(sample.get("sample_seed")),
+        "source_midi_path": str(sample.get("midi_path") or ""),
+        "strict_valid": bool(sample.get("strict_valid", False)),
+        "valid": bool(sample.get("valid", False)),
+        "grammar_gate_passed": bool(sample.get("grammar_gate_passed", False)),
+        "note_count": _int(metrics.get("note_count")),
+        "unique_pitch_count": _int(metrics.get("unique_pitch_count")),
+        "dead_air_ratio": _float(metrics.get("dead_air_ratio")),
+        "direction_change_ratio": _float(contour.get("direction_change_ratio")),
+        "syncopated_onset_ratio": _float(rhythm.get("syncopated_onset_ratio")),
+        "chord_tone_ratio": _float(pitch_roles.get("chord_tone_ratio")),
+        "tension_ratio": _float(pitch_roles.get("tension_ratio")),
+    }
+
+
+def repair_sort_key(candidate: dict[str, Any]) -> tuple[float, int, int, float, float, float]:
+    direction_penalty = 1 if _float(candidate.get("direction_change_ratio")) < 0.50 else 0
+    tension_penalty = 1 if _float(candidate.get("tension_ratio")) < 0.20 else 0
+    return (
+        _float(candidate.get("dead_air_ratio")),
+        direction_penalty,
+        tension_penalty,
+        -_float(candidate.get("direction_change_ratio")),
+        -_float(candidate.get("tension_ratio")),
+        -_float(candidate.get("syncopated_onset_ratio")),
+    )
+
+
+def select_repair_candidates(
+    sweep_report: dict[str, Any],
+    *,
+    selected_per_case: int,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for case in _list(sweep_report.get("cases")):
+        case_dict = _dict(case)
+        probe_report_path = Path(str(case_dict.get("probe_report_path") or ""))
+        probe_report = read_json(probe_report_path)
+        strict_samples = [
+            compact_probe_sample(case_dict, _dict(sample))
+            for sample in _list(probe_report.get("samples"))
+            if bool(_dict(sample).get("strict_valid", False))
+        ]
+        strict_samples = [
+            sample for sample in strict_samples if Path(str(sample["source_midi_path"])).exists()
+        ]
+        if len(strict_samples) < int(selected_per_case):
+            raise SoloYieldDeadAirDensityRepairPackageError(
+                f"not enough strict samples for case {case_dict.get('label')}"
+            )
+        selected.extend(sorted(strict_samples, key=repair_sort_key)[: int(selected_per_case)])
+    return selected
+
+
+def source_candidate_metrics(listening_package: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "dead_air_ratio": _float(item.get("dead_air_ratio")),
+            "direction_change_ratio": _float(item.get("direction_change_ratio")),
+            "tension_ratio": _float(item.get("tension_ratio")),
+            "note_count": _int(item.get("note_count")),
+        }
+        for item in _list(listening_package.get("candidates"))
+    ]
+
+
+def copy_selected_midis(selected: Sequence[dict[str, Any]], output_dir: Path) -> list[dict[str, Any]]:
+    midi_dir = output_dir / "midi"
+    midi_dir.mkdir(parents=True, exist_ok=True)
+    copied: list[dict[str, Any]] = []
+    for index, candidate in enumerate(selected, start=1):
+        source = Path(str(candidate["source_midi_path"]))
+        target = (
+            midi_dir
+            / f"candidate_{index:02d}_{candidate['case_label']}_sample_{int(candidate['sample_index']):02d}.mid"
+        )
+        shutil.copy2(source, target)
+        copied.append(
+            {
+                **candidate,
+                "repair_index": index,
+                "repair_midi_path": str(target),
+                "repair_midi_sha256": sha256_file(target),
+            }
+        )
+    return copied
+
+
+def render_selected(
+    candidates: Sequence[dict[str, Any]],
+    *,
+    output_dir: Path,
+    renderer: str,
+    soundfont: str,
+    sample_rate: int,
+    render_audio: bool,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    renderer_path = renderer or shutil.which("fluidsynth") or ""
+    soundfont_path = resolve_soundfont(soundfont)
+    setup = {
+        "renderer_path": renderer_path,
+        "soundfont_path": soundfont_path,
+        "sample_rate": int(sample_rate),
+        "render_attempted": bool(render_audio and renderer_path and soundfont_path),
+    }
+    if not setup["render_attempted"]:
+        return [], setup
+
+    renderer_file = Path(renderer_path)
+    soundfont_file = Path(soundfont_path).expanduser()
+    if not renderer_file.exists():
+        raise SoloYieldDeadAirDensityRepairPackageError(f"renderer not found: {renderer_file}")
+    if not soundfont_file.exists():
+        raise SoloYieldDeadAirDensityRepairPackageError(f"soundfont not found: {soundfont_file}")
+    setup["soundfont_sha256"] = sha256_file(soundfont_file)
+
+    audio_dir = output_dir / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    rendered: list[dict[str, Any]] = []
+    for candidate in candidates:
+        wav_path = (
+            audio_dir
+            / f"candidate_{int(candidate['repair_index']):02d}_{candidate['case_label']}_sample_{int(candidate['sample_index']):02d}.wav"
+        )
+        command = [
+            str(renderer_file),
+            "-ni",
+            "-F",
+            str(wav_path),
+            "-r",
+            str(sample_rate),
+            str(soundfont_file),
+            str(candidate["repair_midi_path"]),
+        ]
+        completed = subprocess.run(command, check=False, text=True, capture_output=True)
+        if completed.returncode != 0:
+            raise SoloYieldDeadAirDensityRepairPackageError(
+                f"audio render failed for candidate {candidate['repair_index']}: "
+                f"{completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "repair_index": int(candidate["repair_index"]),
+                "case_label": candidate["case_label"],
+                "sample_index": int(candidate["sample_index"]),
+                "source_midi_path": str(candidate["repair_midi_path"]),
+                "wav_file": wav_meta(wav_path),
+                "command": command,
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered, setup
+
+
+def metric_summary(candidates: Sequence[dict[str, Any]], *, major_dead_air_threshold: float) -> dict[str, Any]:
+    dead_air_values = [_float(item.get("dead_air_ratio")) for item in candidates]
+    direction_values = [_float(item.get("direction_change_ratio")) for item in candidates]
+    tension_values = [_float(item.get("tension_ratio")) for item in candidates]
+    note_counts = [_float(item.get("note_count")) for item in candidates]
+    return {
+        "candidate_count": len(candidates),
+        "dead_air_avg": avg(dead_air_values),
+        "dead_air_max": max(dead_air_values) if dead_air_values else 0.0,
+        "dead_air_high_count": sum(1 for value in dead_air_values if value > major_dead_air_threshold),
+        "direction_change_avg": avg(direction_values),
+        "tension_avg": avg(tension_values),
+        "note_count_avg": avg(note_counts),
+    }
+
+
+def build_repair_package(
+    *,
+    sweep_report: dict[str, Any],
+    source_listening_package: dict[str, Any],
+    output_dir: Path,
+    selected_per_case: int,
+    major_dead_air_threshold: float,
+    renderer: str,
+    soundfont: str,
+    sample_rate: int,
+    render_audio: bool = True,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _reject_quality_claim(sweep_report, source_listening_package)
+    selected = select_repair_candidates(sweep_report, selected_per_case=int(selected_per_case))
+    copied = copy_selected_midis(selected, output_dir=output_dir)
+    rendered, render_setup = render_selected(
+        copied,
+        output_dir=output_dir,
+        renderer=renderer,
+        soundfont=soundfont,
+        sample_rate=int(sample_rate),
+        render_audio=bool(render_audio),
+    )
+    source_metrics = source_candidate_metrics(source_listening_package)
+    source_summary = metric_summary(
+        source_metrics,
+        major_dead_air_threshold=float(major_dead_air_threshold),
+    )
+    repair_summary = metric_summary(
+        copied,
+        major_dead_air_threshold=float(major_dead_air_threshold),
+    )
+    dead_air_avg_delta = source_summary["dead_air_avg"] - repair_summary["dead_air_avg"]
+    dead_air_high_count_delta = (
+        source_summary["dead_air_high_count"] - repair_summary["dead_air_high_count"]
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_reports": {
+            "sweep_report": sweep_report.get("output_dir"),
+            "source_listening_package": source_listening_package.get("output_dir"),
+        },
+        "request": {
+            "selected_per_case": int(selected_per_case),
+            "major_dead_air_threshold": float(major_dead_air_threshold),
+        },
+        "source_summary": source_summary,
+        "repair_summary": {
+            **repair_summary,
+            "candidate_midi_files_copied": len(copied),
+            "candidate_wav_files_rendered": len(rendered),
+            "dead_air_avg_delta": dead_air_avg_delta,
+            "dead_air_high_count_delta": dead_air_high_count_delta,
+        },
+        "selected_candidates": copied,
+        "render_setup": render_setup,
+        "rendered_audio_files": rendered,
+        "decision": {
+            "current_boundary": "music_transformer_solo_yield_dead_air_density_balance_repair",
+            "next_boundary": "music_transformer_solo_yield_dead_air_density_balance_repair_rubric_review",
+            "critical_user_input_required": False,
+            "reason": "source strict-valid pool contains lower dead-air candidates; repackage before changing model or decoder",
+        },
+        "readiness": {
+            "dead_air_density_repair_completed": True,
+            "dead_air_avg_reduced": dead_air_avg_delta > 0,
+            "dead_air_high_count_reduced": dead_air_high_count_delta > 0,
+            "technical_wav_render_completed": len(rendered) == len(copied),
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "direction_tension_tradeoff_resolved",
+            "repair_listening_preference",
+        ],
+    }
+
+
+def validate_repair_package(
+    report: dict[str, Any],
+    *,
+    min_candidate_count: int,
+    require_dead_air_avg_reduced: bool,
+    require_wav_rendered: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    if str(report.get("schema_version")) != SCHEMA_VERSION:
+        raise SoloYieldDeadAirDensityRepairPackageError("schema version mismatch")
+    repair_summary = _dict(report.get("repair_summary"))
+    readiness = _dict(report.get("readiness"))
+    if _int(repair_summary.get("candidate_count")) < int(min_candidate_count):
+        raise SoloYieldDeadAirDensityRepairPackageError("candidate count below requirement")
+    if require_dead_air_avg_reduced and not bool(readiness.get("dead_air_avg_reduced", False)):
+        raise SoloYieldDeadAirDensityRepairPackageError("dead-air average reduction required")
+    if require_wav_rendered and not bool(readiness.get("technical_wav_render_completed", False)):
+        raise SoloYieldDeadAirDensityRepairPackageError("WAV render completion required")
+    if require_no_quality_claim:
+        claimed = [
+            key
+            for key in ("musical_quality_claimed", "artist_style_claimed", "production_ready_claimed")
+            if bool(readiness.get(key, True))
+        ]
+        if claimed:
+            raise SoloYieldDeadAirDensityRepairPackageError(
+                f"unexpected quality claim: {claimed}"
+            )
+    return {
+        "schema_version": str(report.get("schema_version")),
+        "candidate_count": _int(repair_summary.get("candidate_count")),
+        "candidate_midi_files_copied": _int(repair_summary.get("candidate_midi_files_copied")),
+        "candidate_wav_files_rendered": _int(repair_summary.get("candidate_wav_files_rendered")),
+        "source_dead_air_avg": _float(_dict(report.get("source_summary")).get("dead_air_avg")),
+        "repair_dead_air_avg": _float(repair_summary.get("dead_air_avg")),
+        "dead_air_avg_delta": _float(repair_summary.get("dead_air_avg_delta")),
+        "source_dead_air_high_count": _int(_dict(report.get("source_summary")).get("dead_air_high_count")),
+        "repair_dead_air_high_count": _int(repair_summary.get("dead_air_high_count")),
+        "dead_air_high_count_delta": _int(repair_summary.get("dead_air_high_count_delta")),
+        "dead_air_avg_reduced": bool(readiness.get("dead_air_avg_reduced", False)),
+        "technical_wav_render_completed": bool(readiness.get("technical_wav_render_completed", False)),
+        "next_boundary": str(_dict(report.get("decision")).get("next_boundary") or ""),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    source = report["source_summary"]
+    repair = report["repair_summary"]
+    decision = report["decision"]
+    readiness = report["readiness"]
+    lines = [
+        "# Music Transformer Solo Yield Dead-Air Density Repair Package",
+        "",
+        "## Summary",
+        "",
+        f"- candidate count: `{repair['candidate_count']}`",
+        f"- MIDI/WAV: `{repair['candidate_midi_files_copied']}` / `{repair['candidate_wav_files_rendered']}`",
+        f"- source dead-air avg/max: `{float(source['dead_air_avg']):.4f}` / `{float(source['dead_air_max']):.4f}`",
+        f"- repair dead-air avg/max: `{float(repair['dead_air_avg']):.4f}` / `{float(repair['dead_air_max']):.4f}`",
+        f"- dead-air avg delta: `{float(repair['dead_air_avg_delta']):.4f}`",
+        f"- source/repair dead-air high count: `{source['dead_air_high_count']}` / `{repair['dead_air_high_count']}`",
+        f"- dead-air high count delta: `{repair['dead_air_high_count_delta']}`",
+        f"- source direction avg: `{float(source['direction_change_avg']):.4f}`",
+        f"- repair direction avg: `{float(repair['direction_change_avg']):.4f}`",
+        f"- source tension avg: `{float(source['tension_avg']):.4f}`",
+        f"- repair tension avg: `{float(repair['tension_avg']):.4f}`",
+        f"- technical WAV render completed: `{_bool_token(readiness['technical_wav_render_completed'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Selected Candidates",
+        "",
+        "| idx | case | sample | notes | dead air | direction | tension | MIDI | WAV |",
+        "|---:|---|---:|---:|---:|---:|---:|---|---|",
+    ]
+    rendered_by_index = {
+        int(item["repair_index"]): _dict(item.get("wav_file")).get("path", "")
+        for item in report.get("rendered_audio_files", [])
+    }
+    for item in report.get("selected_candidates", []):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item["repair_index"]),
+                    f"`{item['case_label']}`",
+                    str(item["sample_index"]),
+                    str(item["note_count"]),
+                    f"{float(item['dead_air_ratio']):.4f}",
+                    f"{float(item['direction_change_ratio']):.4f}",
+                    f"{float(item['tension_ratio']):.4f}",
+                    f"`{item['repair_midi_path']}`",
+                    f"`{rendered_by_index.get(int(item['repair_index']), '')}`",
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build dead-air/density repair package")
+    parser.add_argument("--sweep_report", type=str, required=True)
+    parser.add_argument("--source_listening_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_dead_air_density_repair",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--selected_per_case", type=int, default=2)
+    parser.add_argument("--major_dead_air_threshold", type=float, default=0.68)
+    parser.add_argument("--renderer", type=str, default="")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--skip_render", action="store_true")
+    parser.add_argument("--min_candidate_count", type=int, default=8)
+    parser.add_argument("--require_dead_air_avg_reduced", action="store_true")
+    parser.add_argument("--require_wav_rendered", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_repair_package(
+        sweep_report=read_json(Path(args.sweep_report)),
+        source_listening_package=read_json(Path(args.source_listening_package)),
+        output_dir=output_dir,
+        selected_per_case=int(args.selected_per_case),
+        major_dead_air_threshold=float(args.major_dead_air_threshold),
+        renderer=str(args.renderer),
+        soundfont=str(args.soundfont),
+        sample_rate=int(args.sample_rate),
+        render_audio=not bool(args.skip_render),
+    )
+    summary = validate_repair_package(
+        report,
+        min_candidate_count=int(args.min_candidate_count),
+        require_dead_air_avg_reduced=bool(args.require_dead_air_avg_reduced),
+        require_wav_rendered=bool(args.require_wav_rendered),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "dead_air_density_repair_package.json", report)
+    write_json(output_dir / "dead_air_density_repair_package_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "dead_air_density_repair_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_dead_air_density_repair_package.py
+++ b/tests/test_music_transformer_solo_yield_dead_air_density_repair_package.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.assess_stage_b_generic_base_readiness import write_json
+from scripts.build_music_transformer_solo_yield_dead_air_density_repair_package import (
+    SoloYieldDeadAirDensityRepairPackageError,
+    build_repair_package,
+    select_repair_candidates,
+    validate_repair_package,
+)
+
+
+def sample(sample_index: int, midi_path: Path, *, dead_air: float, direction: float = 0.55) -> dict:
+    return {
+        "sample_index": sample_index,
+        "sample_seed": 1000 + sample_index,
+        "midi_path": str(midi_path),
+        "strict_valid": True,
+        "valid": True,
+        "grammar_gate_passed": True,
+        "metrics": {
+            "note_count": 30 + sample_index,
+            "unique_pitch_count": 12,
+            "dead_air_ratio": dead_air,
+        },
+        "phrase_contour": {
+            "direction_change_ratio": direction,
+        },
+        "rhythm_profile": {
+            "syncopated_onset_ratio": 0.80,
+        },
+        "pitch_roles": {
+            "chord_tone_ratio": 0.44,
+            "tension_ratio": 0.24,
+        },
+    }
+
+
+def source_listening_package(*, quality_claim: bool = False) -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_listening_package_v1",
+        "output_dir": "outputs/source_listening",
+        "candidate_count": 2,
+        "candidates": [
+            {
+                "dead_air_ratio": 0.72,
+                "direction_change_ratio": 0.60,
+                "tension_ratio": 0.24,
+                "note_count": 30,
+            },
+            {
+                "dead_air_ratio": 0.70,
+                "direction_change_ratio": 0.55,
+                "tension_ratio": 0.24,
+                "note_count": 31,
+            },
+        ],
+        "readiness": {
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def fixture_sweep(temp_dir: Path) -> dict:
+    sample_dir = temp_dir / "samples"
+    sample_dir.mkdir()
+    midi_paths = []
+    for index in range(1, 5):
+        midi_path = sample_dir / f"sample_{index}.mid"
+        midi_path.write_bytes(f"midi-{index}".encode("ascii"))
+        midi_paths.append(midi_path)
+
+    probe_report = {
+        "samples": [
+            sample(1, midi_paths[0], dead_air=0.74, direction=0.70),
+            sample(2, midi_paths[1], dead_air=0.54, direction=0.45),
+            sample(3, midi_paths[2], dead_air=0.58, direction=0.60),
+            sample(4, midi_paths[3], dead_air=0.62, direction=0.55),
+        ]
+    }
+    probe_path = temp_dir / "probe.json"
+    write_json(probe_path, probe_report)
+    return {
+        "schema_version": "music_transformer_solo_yield_sweep_v1",
+        "output_dir": "outputs/sweep",
+        "cases": [
+            {
+                "label": "minor_backdoor",
+                "chords": "Cm7,F7,Bbmaj7,Ebmaj7",
+                "seed": 2300,
+                "probe_report_path": str(probe_path),
+            }
+        ],
+        "readiness": {
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldDeadAirDensityRepairPackageTest(unittest.TestCase):
+    def test_selects_low_dead_air_candidates_from_probe_pool(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            selected = select_repair_candidates(fixture_sweep(temp_dir), selected_per_case=2)
+
+        self.assertEqual([item["sample_index"] for item in selected], [2, 3])
+        self.assertEqual([round(item["dead_air_ratio"], 2) for item in selected], [0.54, 0.58])
+
+    def test_builds_repair_package_with_dead_air_reduction_without_render(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            report = build_repair_package(
+                sweep_report=fixture_sweep(temp_dir),
+                source_listening_package=source_listening_package(),
+                output_dir=temp_dir / "repair",
+                selected_per_case=2,
+                major_dead_air_threshold=0.68,
+                renderer="",
+                soundfont="",
+                sample_rate=44100,
+                render_audio=False,
+            )
+        summary = validate_repair_package(
+            report,
+            min_candidate_count=2,
+            require_dead_air_avg_reduced=True,
+            require_wav_rendered=False,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["candidate_count"], 2)
+        self.assertEqual(summary["candidate_midi_files_copied"], 2)
+        self.assertEqual(summary["candidate_wav_files_rendered"], 0)
+        self.assertGreater(summary["dead_air_avg_delta"], 0.0)
+        self.assertEqual(summary["source_dead_air_high_count"], 2)
+        self.assertEqual(summary["repair_dead_air_high_count"], 0)
+        self.assertTrue(summary["dead_air_avg_reduced"])
+        self.assertFalse(summary["technical_wav_render_completed"])
+        self.assertFalse(summary["musical_quality_claimed"])
+
+    def test_validation_requires_wav_when_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            report = build_repair_package(
+                sweep_report=fixture_sweep(temp_dir),
+                source_listening_package=source_listening_package(),
+                output_dir=temp_dir / "repair",
+                selected_per_case=2,
+                major_dead_air_threshold=0.68,
+                renderer="",
+                soundfont="",
+                sample_rate=44100,
+                render_audio=False,
+            )
+
+        with self.assertRaises(SoloYieldDeadAirDensityRepairPackageError):
+            validate_repair_package(
+                report,
+                min_candidate_count=2,
+                require_dead_air_avg_reduced=True,
+                require_wav_rendered=True,
+                require_no_quality_claim=True,
+            )
+
+    def test_rejects_quality_claim_in_source(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            with self.assertRaises(SoloYieldDeadAirDensityRepairPackageError):
+                build_repair_package(
+                    sweep_report=fixture_sweep(temp_dir),
+                    source_listening_package=source_listening_package(quality_claim=True),
+                    output_dir=temp_dir / "repair",
+                    selected_per_case=2,
+                    major_dead_air_threshold=0.68,
+                    renderer="",
+                    soundfont="",
+                    sample_rate=44100,
+                    render_audio=False,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- dead-air/density repair package script added
- #1344 strict-valid sample pool repackaged by lower dead-air candidates
- repaired MIDI/WAV package generated locally

## Context

- #1368 selected repair target: `dead_air_density_balance_repair`
- source review package: #1346 broader repaired listening package
- source dead-air avg/max: `0.6583` / `0.7241`
- repair dead-air avg/max: `0.5806` / `0.6207`
- dead-air high count: `2 -> 0`
- direction avg: `0.5887 -> 0.4912`
- tension avg: `0.2500 -> 0.2326`

## Scope

- case별 low-dead-air strict-valid 후보 재선별
- repaired MIDI files copied: `8`
- repaired WAV files rendered: `8`
- source/repair dead-air delta recorded
- direction/tension tradeoff left as remaining risk

## Validation

- `.venv/bin/python -m py_compile scripts/build_music_transformer_solo_yield_dead_air_density_repair_package.py tests/test_music_transformer_solo_yield_dead_air_density_repair_package.py`
- `.venv/bin/python -m unittest tests.test_music_transformer_solo_yield_dead_air_density_repair_package`
- `.venv/bin/python scripts/build_music_transformer_solo_yield_dead_air_density_repair_package.py --run_id issue_1370_dead_air_density_repair_package --sweep_report outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/solo_yield_sweep_report.json --source_listening_package outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1346_broader_repaired_listening_package/listening_review_package.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_DENSITY_REPAIR_PACKAGE_2026-06-11.md --selected_per_case 2 --major_dead_air_threshold 0.68 --min_candidate_count 8 --require_dead_air_avg_reduced --require_wav_rendered --require_no_quality_claim`
- `rg -n --hidden "codex|Codex|CODEX|ChatGPT|Claude|assistant" scripts/build_music_transformer_solo_yield_dead_air_density_repair_package.py tests/test_music_transformer_solo_yield_dead_air_density_repair_package.py docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_DENSITY_REPAIR_PACKAGE_2026-06-11.md`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- dead-air objective improved, but direction/tension averages decreased
- repair listening preference: `not_proven`
- stable jazz solo quality: `not_proven`
- raw audio output remains local evidence, not repository artifact upload

Closes #1370