### PR TITLE
Stage B MIDI-to-solo tension color balance repair package

### DIFF
--- a/docs/STAGE_B_MIDI_TO_SOLO_TENSION_COLOR_BALANCE_REPAIR_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TENSION_COLOR_BALANCE_REPAIR_PACKAGE_2026-06-11.md
@@ -1,0 +1,43 @@
+# Music Transformer Solo Yield Tension Color Balance Repair Package
+
+## Summary
+
+- candidate count: `8`
+- MIDI/WAV: `8` / `8`
+- source tension avg: `0.1979`
+- repair tension avg: `0.2431`
+- tension avg delta: `0.0451`
+- source/repair tension low count: `4` / `2`
+- tension low count delta: `2`
+- source direction avg: `0.6016`
+- repair direction avg: `0.5653`
+- direction avg delta: `-0.0363`
+- repair direction low count: `0`
+- source dead-air avg/max: `0.6416` / `0.6667`
+- repair dead-air avg/max: `0.6331` / `0.6667`
+- dead-air avg delta: `0.0085`
+- repair dead-air guard violation count: `0`
+- technical WAV render completed: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_tension_color_balance_repair_rubric_review`
+
+## Selected Candidates
+
+| idx | case | sample | notes | dead air | direction | syncopation | tension | MIDI | WAV |
+|---:|---|---:|---:|---:|---:|---:|---:|---|---|
+| 1 | `minor_backdoor` | 1 | 30 | 0.6207 | 0.5294 | 0.7222 | 0.2222 | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_01_minor_backdoor_sample_01.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/audio/candidate_01_minor_backdoor_sample_01.wav` |
+| 2 | `minor_backdoor` | 9 | 32 | 0.6452 | 0.5000 | 0.8611 | 0.1667 | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_02_minor_backdoor_sample_09.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/audio/candidate_02_minor_backdoor_sample_09.wav` |
+| 3 | `major_ii_v_turnaround` | 6 | 28 | 0.6667 | 0.6364 | 0.7778 | 0.2500 | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_03_major_ii_v_turnaround_sample_06.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/audio/candidate_03_major_ii_v_turnaround_sample_06.wav` |
+| 4 | `major_ii_v_turnaround` | 9 | 34 | 0.6667 | 0.6176 | 0.8611 | 0.1667 | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_04_major_ii_v_turnaround_sample_09.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/audio/candidate_04_major_ii_v_turnaround_sample_09.wav` |
+| 5 | `dominant_cycle` | 8 | 33 | 0.5625 | 0.5294 | 0.8056 | 0.3056 | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_05_dominant_cycle_sample_08.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/audio/candidate_05_dominant_cycle_sample_08.wav` |
+| 6 | `dominant_cycle` | 4 | 31 | 0.6667 | 0.5882 | 0.8333 | 0.2500 | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_06_dominant_cycle_sample_04.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/audio/candidate_06_dominant_cycle_sample_04.wav` |
+| 7 | `rhythm_turnaround` | 7 | 34 | 0.6364 | 0.5152 | 0.8056 | 0.3056 | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_07_rhythm_turnaround_sample_07.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/audio/candidate_07_rhythm_turnaround_sample_07.wav` |
+| 8 | `rhythm_turnaround` | 5 | 31 | 0.6000 | 0.6061 | 0.6944 | 0.2778 | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_08_rhythm_turnaround_sample_05.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/audio/candidate_08_rhythm_turnaround_sample_05.wav` |
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `tension_threshold_calibration`
+- `dead_air_watch_resolved`
+- `repair_listening_preference`

--- a/scripts/build_music_transformer_solo_yield_tension_color_balance_repair_package.py
+++ b/scripts/build_music_transformer_solo_yield_tension_color_balance_repair_package.py
@@ -1,0 +1,438 @@
+"""Build a tension/color balanced repair package from solo-yield probe samples."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.build_music_transformer_solo_yield_dead_air_density_repair_package import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _float,
+    _int,
+    _list,
+    _reject_quality_claim,
+    compact_probe_sample,
+    copy_selected_midis,
+    read_json,
+    render_selected,
+)
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_tension_color_balance_repair_package_v1"
+
+
+class SoloYieldTensionColorBalanceRepairPackageError(ValueError):
+    pass
+
+
+def avg(values: Sequence[float]) -> float:
+    return float(mean(values)) if values else 0.0
+
+
+def package_candidates(report: dict[str, Any]) -> list[Any]:
+    candidates = _list(report.get("candidates"))
+    if candidates:
+        return candidates
+    return _list(report.get("selected_candidates"))
+
+
+def candidate_metrics(report: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "dead_air_ratio": _float(_dict(item).get("dead_air_ratio")),
+            "direction_change_ratio": _float(_dict(item).get("direction_change_ratio")),
+            "syncopated_onset_ratio": _float(_dict(item).get("syncopated_onset_ratio")),
+            "tension_ratio": _float(_dict(item).get("tension_ratio")),
+            "note_count": _int(_dict(item).get("note_count")),
+        }
+        for item in package_candidates(report)
+    ]
+
+
+def metric_summary(
+    candidates: Sequence[dict[str, Any]],
+    *,
+    max_dead_air_ratio: float,
+    min_direction_change_ratio: float,
+    min_tension_ratio: float,
+) -> dict[str, Any]:
+    dead_air_values = [_float(item.get("dead_air_ratio")) for item in candidates]
+    direction_values = [_float(item.get("direction_change_ratio")) for item in candidates]
+    syncopation_values = [_float(item.get("syncopated_onset_ratio")) for item in candidates]
+    tension_values = [_float(item.get("tension_ratio")) for item in candidates]
+    note_counts = [_float(item.get("note_count")) for item in candidates]
+    return {
+        "candidate_count": len(candidates),
+        "dead_air_avg": avg(dead_air_values),
+        "dead_air_max": max(dead_air_values) if dead_air_values else 0.0,
+        "dead_air_guard_violation_count": sum(
+            1 for value in dead_air_values if value > float(max_dead_air_ratio)
+        ),
+        "direction_change_avg": avg(direction_values),
+        "direction_low_count": sum(
+            1 for value in direction_values if value < float(min_direction_change_ratio)
+        ),
+        "syncopation_avg": avg(syncopation_values),
+        "tension_avg": avg(tension_values),
+        "tension_low_count": sum(1 for value in tension_values if value < float(min_tension_ratio)),
+        "note_count_avg": avg(note_counts),
+    }
+
+
+def tension_sort_key(candidate: dict[str, Any]) -> tuple[float, float, float, float]:
+    return (
+        -_float(candidate.get("tension_ratio")),
+        -_float(candidate.get("direction_change_ratio")),
+        _float(candidate.get("dead_air_ratio")),
+        -_float(candidate.get("syncopated_onset_ratio")),
+    )
+
+
+def select_repair_candidates(
+    sweep_report: dict[str, Any],
+    *,
+    selected_per_case: int,
+    max_dead_air_ratio: float,
+    min_direction_change_ratio: float,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for case in _list(sweep_report.get("cases")):
+        case_dict = _dict(case)
+        probe_report_path = Path(str(case_dict.get("probe_report_path") or ""))
+        probe_report = read_json(probe_report_path)
+        guarded_samples = [
+            compact_probe_sample(case_dict, _dict(sample))
+            for sample in _list(probe_report.get("samples"))
+            if bool(_dict(sample).get("strict_valid", False))
+        ]
+        guarded_samples = [
+            sample
+            for sample in guarded_samples
+            if Path(str(sample["source_midi_path"])).exists()
+            and _float(sample.get("dead_air_ratio")) <= float(max_dead_air_ratio)
+            and _float(sample.get("direction_change_ratio")) >= float(min_direction_change_ratio)
+        ]
+        if len(guarded_samples) < int(selected_per_case):
+            raise SoloYieldTensionColorBalanceRepairPackageError(
+                f"not enough guarded strict samples for case {case_dict.get('label')}"
+            )
+        selected.extend(sorted(guarded_samples, key=tension_sort_key)[: int(selected_per_case)])
+    return selected
+
+
+def build_repair_package(
+    *,
+    sweep_report: dict[str, Any],
+    source_repair_package: dict[str, Any],
+    output_dir: Path,
+    selected_per_case: int,
+    max_dead_air_ratio: float,
+    min_direction_change_ratio: float,
+    min_tension_ratio: float,
+    renderer: str,
+    soundfont: str,
+    sample_rate: int,
+    render_audio: bool = True,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _reject_quality_claim(sweep_report, source_repair_package)
+    selected = select_repair_candidates(
+        sweep_report,
+        selected_per_case=int(selected_per_case),
+        max_dead_air_ratio=float(max_dead_air_ratio),
+        min_direction_change_ratio=float(min_direction_change_ratio),
+    )
+    copied = copy_selected_midis(selected, output_dir=output_dir)
+    rendered, render_setup = render_selected(
+        copied,
+        output_dir=output_dir,
+        renderer=renderer,
+        soundfont=soundfont,
+        sample_rate=int(sample_rate),
+        render_audio=bool(render_audio),
+    )
+    source_summary = metric_summary(
+        candidate_metrics(source_repair_package),
+        max_dead_air_ratio=float(max_dead_air_ratio),
+        min_direction_change_ratio=float(min_direction_change_ratio),
+        min_tension_ratio=float(min_tension_ratio),
+    )
+    repair_summary = metric_summary(
+        copied,
+        max_dead_air_ratio=float(max_dead_air_ratio),
+        min_direction_change_ratio=float(min_direction_change_ratio),
+        min_tension_ratio=float(min_tension_ratio),
+    )
+    tension_avg_delta = repair_summary["tension_avg"] - source_summary["tension_avg"]
+    tension_low_count_delta = source_summary["tension_low_count"] - repair_summary["tension_low_count"]
+    direction_change_avg_delta = (
+        repair_summary["direction_change_avg"] - source_summary["direction_change_avg"]
+    )
+    dead_air_avg_delta = source_summary["dead_air_avg"] - repair_summary["dead_air_avg"]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_reports": {
+            "sweep_report": sweep_report.get("output_dir"),
+            "source_repair_package": source_repair_package.get("output_dir"),
+        },
+        "request": {
+            "selected_per_case": int(selected_per_case),
+            "max_dead_air_ratio": float(max_dead_air_ratio),
+            "min_direction_change_ratio": float(min_direction_change_ratio),
+            "min_tension_ratio": float(min_tension_ratio),
+        },
+        "source_summary": source_summary,
+        "repair_summary": {
+            **repair_summary,
+            "candidate_midi_files_copied": len(copied),
+            "candidate_wav_files_rendered": len(rendered),
+            "tension_avg_delta": tension_avg_delta,
+            "tension_low_count_delta": tension_low_count_delta,
+            "direction_change_avg_delta": direction_change_avg_delta,
+            "dead_air_avg_delta": dead_air_avg_delta,
+        },
+        "selected_candidates": copied,
+        "render_setup": render_setup,
+        "rendered_audio_files": rendered,
+        "decision": {
+            "current_boundary": "music_transformer_solo_yield_tension_color_balance_repair",
+            "next_boundary": "music_transformer_solo_yield_tension_color_balance_repair_rubric_review",
+            "critical_user_input_required": False,
+            "reason": "phrase-direction repair removed weak direction labels but left low tension-color labels",
+        },
+        "readiness": {
+            "tension_color_balance_repair_completed": True,
+            "tension_avg_increased": tension_avg_delta > 0,
+            "tension_low_count_reduced": tension_low_count_delta > 0,
+            "dead_air_guard_preserved": repair_summary["dead_air_guard_violation_count"] == 0,
+            "direction_guard_preserved": repair_summary["direction_low_count"] == 0,
+            "technical_wav_render_completed": len(rendered) == len(copied),
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "tension_threshold_calibration",
+            "dead_air_watch_resolved",
+            "repair_listening_preference",
+        ],
+    }
+
+
+def validate_repair_package(
+    report: dict[str, Any],
+    *,
+    min_candidate_count: int,
+    require_tension_avg_increased: bool,
+    require_tension_low_count_reduced: bool,
+    require_dead_air_guard: bool,
+    require_direction_guard: bool,
+    require_wav_rendered: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    if str(report.get("schema_version")) != SCHEMA_VERSION:
+        raise SoloYieldTensionColorBalanceRepairPackageError("schema version mismatch")
+    repair_summary = _dict(report.get("repair_summary"))
+    readiness = _dict(report.get("readiness"))
+    if _int(repair_summary.get("candidate_count")) < int(min_candidate_count):
+        raise SoloYieldTensionColorBalanceRepairPackageError("candidate count below requirement")
+    if require_tension_avg_increased and not bool(readiness.get("tension_avg_increased", False)):
+        raise SoloYieldTensionColorBalanceRepairPackageError("tension average increase required")
+    if require_tension_low_count_reduced and not bool(
+        readiness.get("tension_low_count_reduced", False)
+    ):
+        raise SoloYieldTensionColorBalanceRepairPackageError("tension low-count reduction required")
+    if require_dead_air_guard and not bool(readiness.get("dead_air_guard_preserved", False)):
+        raise SoloYieldTensionColorBalanceRepairPackageError("dead-air guard required")
+    if require_direction_guard and not bool(readiness.get("direction_guard_preserved", False)):
+        raise SoloYieldTensionColorBalanceRepairPackageError("direction guard required")
+    if require_wav_rendered and not bool(readiness.get("technical_wav_render_completed", False)):
+        raise SoloYieldTensionColorBalanceRepairPackageError("WAV render completion required")
+    if require_no_quality_claim:
+        claimed = [
+            key
+            for key in ("musical_quality_claimed", "artist_style_claimed", "production_ready_claimed")
+            if bool(readiness.get(key, True))
+        ]
+        if claimed:
+            raise SoloYieldTensionColorBalanceRepairPackageError(
+                f"unexpected quality claim: {claimed}"
+            )
+    source_summary = _dict(report.get("source_summary"))
+    return {
+        "schema_version": str(report.get("schema_version")),
+        "candidate_count": _int(repair_summary.get("candidate_count")),
+        "candidate_midi_files_copied": _int(repair_summary.get("candidate_midi_files_copied")),
+        "candidate_wav_files_rendered": _int(repair_summary.get("candidate_wav_files_rendered")),
+        "source_tension_avg": _float(source_summary.get("tension_avg")),
+        "repair_tension_avg": _float(repair_summary.get("tension_avg")),
+        "tension_avg_delta": _float(repair_summary.get("tension_avg_delta")),
+        "source_tension_low_count": _int(source_summary.get("tension_low_count")),
+        "repair_tension_low_count": _int(repair_summary.get("tension_low_count")),
+        "tension_low_count_delta": _int(repair_summary.get("tension_low_count_delta")),
+        "source_direction_change_avg": _float(source_summary.get("direction_change_avg")),
+        "repair_direction_change_avg": _float(repair_summary.get("direction_change_avg")),
+        "direction_change_avg_delta": _float(repair_summary.get("direction_change_avg_delta")),
+        "source_dead_air_avg": _float(source_summary.get("dead_air_avg")),
+        "repair_dead_air_avg": _float(repair_summary.get("dead_air_avg")),
+        "dead_air_avg_delta": _float(repair_summary.get("dead_air_avg_delta")),
+        "repair_dead_air_guard_violation_count": _int(
+            repair_summary.get("dead_air_guard_violation_count")
+        ),
+        "repair_direction_low_count": _int(repair_summary.get("direction_low_count")),
+        "tension_avg_increased": bool(readiness.get("tension_avg_increased", False)),
+        "tension_low_count_reduced": bool(readiness.get("tension_low_count_reduced", False)),
+        "dead_air_guard_preserved": bool(readiness.get("dead_air_guard_preserved", False)),
+        "direction_guard_preserved": bool(readiness.get("direction_guard_preserved", False)),
+        "technical_wav_render_completed": bool(readiness.get("technical_wav_render_completed", False)),
+        "next_boundary": str(_dict(report.get("decision")).get("next_boundary") or ""),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    source = report["source_summary"]
+    repair = report["repair_summary"]
+    decision = report["decision"]
+    readiness = report["readiness"]
+    lines = [
+        "# Music Transformer Solo Yield Tension Color Balance Repair Package",
+        "",
+        "## Summary",
+        "",
+        f"- candidate count: `{repair['candidate_count']}`",
+        f"- MIDI/WAV: `{repair['candidate_midi_files_copied']}` / `{repair['candidate_wav_files_rendered']}`",
+        f"- source tension avg: `{float(source['tension_avg']):.4f}`",
+        f"- repair tension avg: `{float(repair['tension_avg']):.4f}`",
+        f"- tension avg delta: `{float(repair['tension_avg_delta']):.4f}`",
+        f"- source/repair tension low count: `{source['tension_low_count']}` / `{repair['tension_low_count']}`",
+        f"- tension low count delta: `{repair['tension_low_count_delta']}`",
+        f"- source direction avg: `{float(source['direction_change_avg']):.4f}`",
+        f"- repair direction avg: `{float(repair['direction_change_avg']):.4f}`",
+        f"- direction avg delta: `{float(repair['direction_change_avg_delta']):.4f}`",
+        f"- repair direction low count: `{repair['direction_low_count']}`",
+        f"- source dead-air avg/max: `{float(source['dead_air_avg']):.4f}` / `{float(source['dead_air_max']):.4f}`",
+        f"- repair dead-air avg/max: `{float(repair['dead_air_avg']):.4f}` / `{float(repair['dead_air_max']):.4f}`",
+        f"- dead-air avg delta: `{float(repair['dead_air_avg_delta']):.4f}`",
+        f"- repair dead-air guard violation count: `{repair['dead_air_guard_violation_count']}`",
+        f"- technical WAV render completed: `{_bool_token(readiness['technical_wav_render_completed'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Selected Candidates",
+        "",
+        "| idx | case | sample | notes | dead air | direction | syncopation | tension | MIDI | WAV |",
+        "|---:|---|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    rendered_by_index = {
+        int(item["repair_index"]): _dict(item.get("wav_file")).get("path", "")
+        for item in report.get("rendered_audio_files", [])
+    }
+    for item in report.get("selected_candidates", []):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item["repair_index"]),
+                    f"`{item['case_label']}`",
+                    str(item["sample_index"]),
+                    str(item["note_count"]),
+                    f"{float(item['dead_air_ratio']):.4f}",
+                    f"{float(item['direction_change_ratio']):.4f}",
+                    f"{float(item['syncopated_onset_ratio']):.4f}",
+                    f"{float(item['tension_ratio']):.4f}",
+                    f"`{item['repair_midi_path']}`",
+                    f"`{rendered_by_index.get(int(item['repair_index']), '')}`",
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build tension/color balance repair package")
+    parser.add_argument("--sweep_report", type=str, required=True)
+    parser.add_argument("--source_repair_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--selected_per_case", type=int, default=2)
+    parser.add_argument("--max_dead_air_ratio", type=float, default=0.68)
+    parser.add_argument("--min_direction_change_ratio", type=float, default=0.50)
+    parser.add_argument("--min_tension_ratio", type=float, default=0.20)
+    parser.add_argument("--renderer", type=str, default="")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--skip_render", action="store_true")
+    parser.add_argument("--min_candidate_count", type=int, default=8)
+    parser.add_argument("--require_tension_avg_increased", action="store_true")
+    parser.add_argument("--require_tension_low_count_reduced", action="store_true")
+    parser.add_argument("--require_dead_air_guard", action="store_true")
+    parser.add_argument("--require_direction_guard", action="store_true")
+    parser.add_argument("--require_wav_rendered", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_repair_package(
+        sweep_report=read_json(Path(args.sweep_report)),
+        source_repair_package=read_json(Path(args.source_repair_package)),
+        output_dir=output_dir,
+        selected_per_case=int(args.selected_per_case),
+        max_dead_air_ratio=float(args.max_dead_air_ratio),
+        min_direction_change_ratio=float(args.min_direction_change_ratio),
+        min_tension_ratio=float(args.min_tension_ratio),
+        renderer=str(args.renderer),
+        soundfont=str(args.soundfont),
+        sample_rate=int(args.sample_rate),
+        render_audio=not bool(args.skip_render),
+    )
+    summary = validate_repair_package(
+        report,
+        min_candidate_count=int(args.min_candidate_count),
+        require_tension_avg_increased=bool(args.require_tension_avg_increased),
+        require_tension_low_count_reduced=bool(args.require_tension_low_count_reduced),
+        require_dead_air_guard=bool(args.require_dead_air_guard),
+        require_direction_guard=bool(args.require_direction_guard),
+        require_wav_rendered=bool(args.require_wav_rendered),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "tension_color_balance_repair_package.json", report)
+    write_json(output_dir / "tension_color_balance_repair_package_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "tension_color_balance_repair_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_tension_color_balance_repair_package.py
+++ b/tests/test_music_transformer_solo_yield_tension_color_balance_repair_package.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.assess_stage_b_generic_base_readiness import write_json
+from scripts.build_music_transformer_solo_yield_tension_color_balance_repair_package import (
+    SoloYieldTensionColorBalanceRepairPackageError,
+    build_repair_package,
+    select_repair_candidates,
+    validate_repair_package,
+)
+
+
+def sample(
+    sample_index: int,
+    midi_path: Path,
+    *,
+    dead_air: float,
+    direction: float,
+    tension: float,
+) -> dict:
+    return {
+        "sample_index": sample_index,
+        "sample_seed": 1000 + sample_index,
+        "midi_path": str(midi_path),
+        "strict_valid": True,
+        "valid": True,
+        "grammar_gate_passed": True,
+        "metrics": {
+            "note_count": 30 + sample_index,
+            "unique_pitch_count": 12,
+            "dead_air_ratio": dead_air,
+        },
+        "phrase_contour": {
+            "direction_change_ratio": direction,
+        },
+        "rhythm_profile": {
+            "syncopated_onset_ratio": 0.80,
+        },
+        "pitch_roles": {
+            "chord_tone_ratio": 0.44,
+            "tension_ratio": tension,
+        },
+    }
+
+
+def source_repair_package(*, quality_claim: bool = False) -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_phrase_direction_balance_repair_package_v1",
+        "output_dir": "outputs/source_repair",
+        "selected_candidates": [
+            {
+                "dead_air_ratio": 0.60,
+                "direction_change_ratio": 0.56,
+                "syncopated_onset_ratio": 0.80,
+                "tension_ratio": 0.14,
+                "note_count": 30,
+            },
+            {
+                "dead_air_ratio": 0.62,
+                "direction_change_ratio": 0.58,
+                "syncopated_onset_ratio": 0.80,
+                "tension_ratio": 0.18,
+                "note_count": 31,
+            },
+        ],
+        "readiness": {
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def fixture_sweep(temp_dir: Path) -> dict:
+    sample_dir = temp_dir / "samples"
+    sample_dir.mkdir()
+    midi_paths = []
+    for index in range(1, 5):
+        midi_path = sample_dir / f"sample_{index}.mid"
+        midi_path.write_bytes(f"midi-{index}".encode("ascii"))
+        midi_paths.append(midi_path)
+
+    probe_report = {
+        "samples": [
+            sample(1, midi_paths[0], dead_air=0.70, direction=0.90, tension=0.40),
+            sample(2, midi_paths[1], dead_air=0.54, direction=0.62, tension=0.28),
+            sample(3, midi_paths[2], dead_air=0.58, direction=0.56, tension=0.22),
+            sample(4, midi_paths[3], dead_air=0.62, direction=0.40, tension=0.35),
+        ]
+    }
+    probe_path = temp_dir / "probe.json"
+    write_json(probe_path, probe_report)
+    return {
+        "schema_version": "music_transformer_solo_yield_sweep_v1",
+        "output_dir": "outputs/sweep",
+        "cases": [
+            {
+                "label": "minor_backdoor",
+                "chords": "Cm7,F7,Bbmaj7,Ebmaj7",
+                "seed": 2300,
+                "probe_report_path": str(probe_path),
+            }
+        ],
+        "readiness": {
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldTensionColorBalanceRepairPackageTest(unittest.TestCase):
+    def test_selects_high_tension_candidates_inside_dead_air_and_direction_guards(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            selected = select_repair_candidates(
+                fixture_sweep(temp_dir),
+                selected_per_case=2,
+                max_dead_air_ratio=0.68,
+                min_direction_change_ratio=0.50,
+            )
+
+        self.assertEqual([item["sample_index"] for item in selected], [2, 3])
+        self.assertEqual([round(item["tension_ratio"], 2) for item in selected], [0.28, 0.22])
+
+    def test_builds_repair_package_with_tension_gain_without_render(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            report = build_repair_package(
+                sweep_report=fixture_sweep(temp_dir),
+                source_repair_package=source_repair_package(),
+                output_dir=temp_dir / "repair",
+                selected_per_case=2,
+                max_dead_air_ratio=0.68,
+                min_direction_change_ratio=0.50,
+                min_tension_ratio=0.20,
+                renderer="",
+                soundfont="",
+                sample_rate=44100,
+                render_audio=False,
+            )
+        summary = validate_repair_package(
+            report,
+            min_candidate_count=2,
+            require_tension_avg_increased=True,
+            require_tension_low_count_reduced=True,
+            require_dead_air_guard=True,
+            require_direction_guard=True,
+            require_wav_rendered=False,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["candidate_count"], 2)
+        self.assertEqual(summary["candidate_midi_files_copied"], 2)
+        self.assertEqual(summary["candidate_wav_files_rendered"], 0)
+        self.assertGreater(summary["tension_avg_delta"], 0.0)
+        self.assertEqual(summary["source_tension_low_count"], 2)
+        self.assertEqual(summary["repair_tension_low_count"], 0)
+        self.assertEqual(summary["repair_dead_air_guard_violation_count"], 0)
+        self.assertEqual(summary["repair_direction_low_count"], 0)
+        self.assertTrue(summary["tension_avg_increased"])
+        self.assertTrue(summary["tension_low_count_reduced"])
+        self.assertFalse(summary["technical_wav_render_completed"])
+        self.assertFalse(summary["musical_quality_claimed"])
+
+    def test_validation_requires_direction_guard_when_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            report = build_repair_package(
+                sweep_report=fixture_sweep(temp_dir),
+                source_repair_package=source_repair_package(),
+                output_dir=temp_dir / "repair",
+                selected_per_case=2,
+                max_dead_air_ratio=0.68,
+                min_direction_change_ratio=0.50,
+                min_tension_ratio=0.20,
+                renderer="",
+                soundfont="",
+                sample_rate=44100,
+                render_audio=False,
+            )
+        report["repair_summary"]["direction_low_count"] = 1
+        report["readiness"]["direction_guard_preserved"] = False
+
+        with self.assertRaises(SoloYieldTensionColorBalanceRepairPackageError):
+            validate_repair_package(
+                report,
+                min_candidate_count=2,
+                require_tension_avg_increased=True,
+                require_tension_low_count_reduced=True,
+                require_dead_air_guard=True,
+                require_direction_guard=True,
+                require_wav_rendered=False,
+                require_no_quality_claim=True,
+            )
+
+    def test_rejects_quality_claim_in_source(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            with self.assertRaises(ValueError):
+                build_repair_package(
+                    sweep_report=fixture_sweep(temp_dir),
+                    source_repair_package=source_repair_package(quality_claim=True),
+                    output_dir=temp_dir / "repair",
+                    selected_per_case=2,
+                    max_dead_air_ratio=0.68,
+                    min_direction_change_ratio=0.50,
+                    min_tension_ratio=0.20,
+                    renderer="",
+                    soundfont="",
+                    sample_rate=44100,
+                    render_audio=False,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- tension color balance repair package 추가
- tension-priority candidate selector 추가
- dead-air/direction guard 기반 MIDI/WAV 8개 package 생성

## Context

- #1376 objective rubric result: `low_tension_color=4`, `dead_air_watch=3`
- selected target: `tension_color_balance_repair`
- source package: `outputs/music_transformer_finetune_mvp/solo_yield_phrase_direction_balance_repair/issue_1374_phrase_direction_balance_repair_package/phrase_direction_balance_repair_package.json`
- sweep source: `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/solo_yield_sweep_report.json`

## Scope

- tension-priority candidate selector
- max dead-air ratio guard: `0.68`
- min direction-change ratio guard: `0.50`
- min tension threshold: `0.20`
- package output summary 및 docs 생성

## Result

- MIDI/WAV: `8` / `8`
- tension avg: `0.1979 -> 0.2431`
- tension low count: `4 -> 2`
- direction avg: `0.6016 -> 0.5653`
- direction low count: `0`
- dead-air avg: `0.6416 -> 0.6331`
- dead-air guard violation count: `0`

## Validation

- `.venv/bin/python -m py_compile scripts/build_music_transformer_solo_yield_tension_color_balance_repair_package.py tests/test_music_transformer_solo_yield_tension_color_balance_repair_package.py`
- `.venv/bin/python -m unittest tests.test_music_transformer_solo_yield_tension_color_balance_repair_package`
- `.venv/bin/python scripts/build_music_transformer_solo_yield_tension_color_balance_repair_package.py --run_id issue_1378_tension_color_balance_repair_package --sweep_report outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1344_broader_repaired_sampling_repeatability/solo_yield_sweep_report.json --source_repair_package outputs/music_transformer_finetune_mvp/solo_yield_phrase_direction_balance_repair/issue_1374_phrase_direction_balance_repair_package/phrase_direction_balance_repair_package.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_TENSION_COLOR_BALANCE_REPAIR_PACKAGE_2026-06-11.md --selected_per_case 2 --max_dead_air_ratio 0.68 --min_direction_change_ratio 0.50 --min_tension_ratio 0.20 --renderer /opt/homebrew/bin/fluidsynth --soundfont /Users/ohhalim/.local/share/soundfonts/generaluser-gs/v1.471.sf2 --sample_rate 44100 --min_candidate_count 8 --require_tension_avg_increased --require_tension_low_count_reduced --require_dead_air_guard --require_direction_guard --require_wav_rendered --require_no_quality_claim`
- public artifact tool-name scan: no matches
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- low tension remains for 2 candidates
- direction average regression: `-0.0363`
- objective metric threshold calibration not proven
- musical preference not inferred from proxy metrics

## Follow-up

- tension color repair rubric review
- residual low tension or dead-air watch decision

Closes #1378