### PR TITLE
Stage B MIDI-to-solo tension color repair rubric review

### DIFF
--- a/docs/STAGE_B_MIDI_TO_SOLO_TENSION_COLOR_REPAIR_RUBRIC_REVIEW_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TENSION_COLOR_REPAIR_RUBRIC_REVIEW_2026-06-11.md
@@ -1,0 +1,32 @@
+# Music Transformer Solo Yield Objective Quality Rubric Baseline
+
+## Summary
+
+- candidate count: `8`
+- quality proxy pass/fail: `5` / `3`
+- major label counts: `low_syncopation=1, low_tension_color=2`
+- watch label counts: `dead_air_watch=3`
+- selected repair target: `tension_color_balance_repair`
+- next boundary: `music_transformer_solo_yield_tension_color_balance_repair`
+- critical user input required: `false`
+- musical quality claimed: `false`
+
+## Candidate Labels
+
+| idx | case | rank | notes | dead air | direction | tension | major labels | watch labels | MIDI |
+|---:|---|---:|---:|---:|---:|---:|---|---|---|
+| 1 | `minor_backdoor` | 1 | 30 | 0.6207 | 0.5294 | 0.2222 | `none` | `none` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_01_minor_backdoor_sample_01.mid` |
+| 2 | `minor_backdoor` | 2 | 32 | 0.6452 | 0.5000 | 0.1667 | `low_tension_color` | `none` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_02_minor_backdoor_sample_09.mid` |
+| 3 | `major_ii_v_turnaround` | 3 | 28 | 0.6667 | 0.6364 | 0.2500 | `none` | `dead_air_watch` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_03_major_ii_v_turnaround_sample_06.mid` |
+| 4 | `major_ii_v_turnaround` | 4 | 34 | 0.6667 | 0.6176 | 0.1667 | `low_tension_color` | `dead_air_watch` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_04_major_ii_v_turnaround_sample_09.mid` |
+| 5 | `dominant_cycle` | 5 | 33 | 0.5625 | 0.5294 | 0.3056 | `none` | `none` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_05_dominant_cycle_sample_08.mid` |
+| 6 | `dominant_cycle` | 6 | 31 | 0.6667 | 0.5882 | 0.2500 | `none` | `dead_air_watch` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_06_dominant_cycle_sample_04.mid` |
+| 7 | `rhythm_turnaround` | 7 | 34 | 0.6364 | 0.5152 | 0.3056 | `none` | `none` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_07_rhythm_turnaround_sample_07.mid` |
+| 8 | `rhythm_turnaround` | 8 | 31 | 0.6000 | 0.6061 | 0.2778 | `low_syncopation` | `none` | `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/midi/candidate_08_rhythm_turnaround_sample_05.mid` |
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `rubric_threshold_calibration`
+- `repair_effectiveness`


### PR DESCRIPTION
## Summary

- #1378 tension color balance repair package objective rubric review 기록
- 다음 repair target: `tension_color_balance_repair` 유지

## Context

- #1378 tension avg: `0.1979 -> 0.2431`
- #1378 tension low count: `4 -> 2`
- #1378 direction low count: `0`
- #1378 dead-air guard violation count: `0`
- package path: `outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/tension_color_balance_repair_package.json`

## Result

- quality proxy pass/fail: `5` / `3`
- major labels: `low_tension_color=2`, `low_syncopation=1`
- watch labels: `dead_air_watch=3`
- selected repair target: `tension_color_balance_repair`
- next boundary: `music_transformer_solo_yield_tension_color_balance_repair`

## Scope

- objective rubric review document only

## Validation

- `.venv/bin/python scripts/build_music_transformer_solo_yield_objective_quality_rubric_baseline.py --run_id issue_1380_tension_color_repair_rubric_review --listening_package outputs/music_transformer_finetune_mvp/solo_yield_tension_color_balance_repair/issue_1378_tension_color_balance_repair_package/tension_color_balance_repair_package.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_TENSION_COLOR_REPAIR_RUBRIC_REVIEW_2026-06-11.md --min_candidate_count 8 --expected_target tension_color_balance_repair --require_no_quality_claim`
- public artifact tool-name scan: no matches
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- low tension remains for 2 candidates
- dead-air watch remains for 3 candidates
- objective metric threshold calibration not proven
- musical preference not inferred

## Follow-up

- second tension color balance repair or constrained residual target decision

Closes #1380