### PR TITLE
Stage B MIDI-to-solo residual-aware final review package

### DIFF
--- a/docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_REVIEW_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_REVIEW_PACKAGE_2026-06-11.md
@@ -1,0 +1,35 @@
+# Music Transformer Solo Yield Residual-Aware Final Review Package
+
+## Summary
+
+- candidate count: `8`
+- MIDI/WAV: `8` / `8`
+- quality proxy pass/fail: `6` / `2`
+- residual major labels: `low_tension_color=2`
+- residual watch labels: `dead_air_watch=3`
+- tension repeat feasible: `false`
+- tension repeat blocked cases: `minor_backdoor, major_ii_v_turnaround`
+- review input template written: `true`
+- validated listening input present: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_residual_aware_listening_input_guard`
+
+## Candidate Handoff
+
+| idx | case | MIDI | WAV | major labels | watch labels |
+|---:|---|---|---|---|---|
+| 1 | `minor_backdoor` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/midi/candidate_01_minor_backdoor_sample_01.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/audio/candidate_01_minor_backdoor_sample_01.wav` | `none` | `none` |
+| 2 | `minor_backdoor` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/midi/candidate_02_minor_backdoor_sample_09.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/audio/candidate_02_minor_backdoor_sample_09.wav` | `low_tension_color` | `none` |
+| 3 | `major_ii_v_turnaround` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/midi/candidate_03_major_ii_v_turnaround_sample_06.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/audio/candidate_03_major_ii_v_turnaround_sample_06.wav` | `none` | `dead_air_watch` |
+| 4 | `major_ii_v_turnaround` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/midi/candidate_04_major_ii_v_turnaround_sample_09.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/audio/candidate_04_major_ii_v_turnaround_sample_09.wav` | `low_tension_color` | `dead_air_watch` |
+| 5 | `dominant_cycle` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/midi/candidate_05_dominant_cycle_sample_04.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/audio/candidate_05_dominant_cycle_sample_04.wav` | `none` | `dead_air_watch` |
+| 6 | `dominant_cycle` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/midi/candidate_06_dominant_cycle_sample_08.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/audio/candidate_06_dominant_cycle_sample_08.wav` | `none` | `none` |
+| 7 | `rhythm_turnaround` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/midi/candidate_07_rhythm_turnaround_sample_03.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/audio/candidate_07_rhythm_turnaround_sample_03.wav` | `none` | `none` |
+| 8 | `rhythm_turnaround` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/midi/candidate_08_rhythm_turnaround_sample_09.mid` | `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/audio/candidate_08_rhythm_turnaround_sample_09.wav` | `none` | `none` |
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `residual_tension_resolved`
+- `production_ready_improviser`

--- a/scripts/build_music_transformer_solo_yield_residual_aware_final_review_package.py
+++ b/scripts/build_music_transformer_solo_yield_residual_aware_final_review_package.py
@@ -1,0 +1,429 @@
+"""Build a residual-aware final review package for solo-yield repair candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import sha256_file  # noqa: E402
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_final_review_package_v1"
+REVIEW_INPUT_SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_review_input_v1"
+
+
+class SoloYieldResidualAwareFinalReviewPackageError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldResidualAwareFinalReviewPackageError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _reject_quality_claim(report: dict[str, Any], *, label: str) -> None:
+    readiness = _dict(report.get("readiness"))
+    claimed = [
+        key
+        for key in ("musical_quality_claimed", "artist_style_claimed", "production_ready_claimed")
+        if bool(readiness.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldResidualAwareFinalReviewPackageError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def _require_file(path_value: Any, *, label: str) -> Path:
+    path = Path(str(path_value or ""))
+    if not str(path) or not path.exists() or not path.is_file():
+        raise SoloYieldResidualAwareFinalReviewPackageError(f"{label} missing: {path}")
+    return path
+
+
+def _require_checksum(path: Path, expected: str, *, label: str) -> None:
+    actual = sha256_file(path)
+    if str(expected or "") != actual:
+        raise SoloYieldResidualAwareFinalReviewPackageError(
+            f"{label} checksum mismatch: expected={expected} actual={actual}"
+        )
+
+
+def rendered_audio_by_index(source_package: dict[str, Any]) -> dict[int, dict[str, Any]]:
+    return {
+        _int(row.get("repair_index")): _dict(row)
+        for row in _list(source_package.get("rendered_audio_files"))
+    }
+
+
+def rubric_labels_by_index(rubric_report: dict[str, Any]) -> dict[int, dict[str, Any]]:
+    return {
+        _int(row.get("review_index")): _dict(row)
+        for row in _list(rubric_report.get("candidate_labels"))
+    }
+
+
+def build_candidate_rows(
+    *,
+    source_package: dict[str, Any],
+    rubric_report: dict[str, Any],
+) -> list[dict[str, Any]]:
+    rendered_by_index = rendered_audio_by_index(source_package)
+    labels_by_index = rubric_labels_by_index(rubric_report)
+    rows: list[dict[str, Any]] = []
+    for candidate in _list(source_package.get("selected_candidates")):
+        item = _dict(candidate)
+        review_index = _int(item.get("repair_index"))
+        midi_path = _require_file(item.get("repair_midi_path"), label="candidate MIDI")
+        _require_checksum(midi_path, str(item.get("repair_midi_sha256") or ""), label="MIDI")
+
+        rendered = rendered_by_index.get(review_index, {})
+        wav_file = _dict(rendered.get("wav_file"))
+        wav_path = _require_file(wav_file.get("path"), label="candidate WAV")
+        _require_checksum(wav_path, str(wav_file.get("sha256") or ""), label="WAV")
+        labels = labels_by_index.get(review_index, {})
+        rows.append(
+            {
+                "review_index": review_index,
+                "case_label": str(item.get("case_label") or ""),
+                "sample_index": _int(item.get("sample_index")),
+                "sample_seed": _int(item.get("sample_seed")),
+                "review_midi_path": str(midi_path),
+                "review_wav_path": str(wav_path),
+                "review_midi_sha256": str(item.get("repair_midi_sha256") or ""),
+                "review_wav_sha256": str(wav_file.get("sha256") or ""),
+                "duration_seconds": _float(wav_file.get("duration_seconds")),
+                "sample_rate": _int(wav_file.get("sample_rate")),
+                "metrics": {
+                    "note_count": _int(item.get("note_count")),
+                    "dead_air_ratio": _float(item.get("dead_air_ratio")),
+                    "direction_change_ratio": _float(item.get("direction_change_ratio")),
+                    "syncopated_onset_ratio": _float(item.get("syncopated_onset_ratio")),
+                    "chord_tone_ratio": _float(item.get("chord_tone_ratio")),
+                    "tension_ratio": _float(item.get("tension_ratio")),
+                },
+                "rubric_major_labels": _list(labels.get("major_labels")),
+                "rubric_watch_labels": _list(labels.get("watch_labels")),
+                "quality_proxy_pass": bool(labels.get("quality_proxy_pass", False)),
+            }
+        )
+    return rows
+
+
+def build_review_input_template(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": REVIEW_INPUT_SCHEMA_VERSION,
+        "review_status": "pending",
+        "overall_decision": "pending",
+        "preferred_review_index": None,
+        "reviewer_notes": "",
+        "candidates": [
+            {
+                "review_index": _int(row.get("review_index")),
+                "case_label": row.get("case_label"),
+                "decision": "pending",
+                "usable_as_jazz_solo_phrase": None,
+                "primary_failure": None,
+                "notes": "",
+            }
+            for row in candidates
+        ],
+        "allowed_primary_failures": [
+            "not_solo_like",
+            "too_mechanical",
+            "too_sparse",
+            "too_dense",
+            "rhythm_not_swinging",
+            "outside_harmony",
+            "weak_phrase_shape",
+            "audio_render_issue",
+            "none",
+        ],
+    }
+
+
+def _range(values: list[float]) -> dict[str, float]:
+    return {
+        "min": min(values, default=0.0),
+        "max": max(values, default=0.0),
+        "avg": float(mean(values)) if values else 0.0,
+    }
+
+
+def build_final_review_package(
+    *,
+    source_package: dict[str, Any],
+    rubric_report: dict[str, Any],
+    feasibility_decision: dict[str, Any],
+    output_dir: Path,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _reject_quality_claim(source_package, label="source_package")
+    _reject_quality_claim(rubric_report, label="rubric_report")
+    _reject_quality_claim(feasibility_decision, label="feasibility_decision")
+    candidates = build_candidate_rows(
+        source_package=source_package,
+        rubric_report=rubric_report,
+    )
+    if not candidates:
+        raise SoloYieldResidualAwareFinalReviewPackageError("candidate rows required")
+    review_input_template = build_review_input_template(candidates)
+    rubric_aggregate = _dict(rubric_report.get("aggregate"))
+    feasibility = _dict(feasibility_decision.get("decision"))
+    dead_air = [_float(_dict(row.get("metrics")).get("dead_air_ratio")) for row in candidates]
+    direction = [_float(_dict(row.get("metrics")).get("direction_change_ratio")) for row in candidates]
+    syncopation = [_float(_dict(row.get("metrics")).get("syncopated_onset_ratio")) for row in candidates]
+    tension = [_float(_dict(row.get("metrics")).get("tension_ratio")) for row in candidates]
+    aggregate = {
+        "candidate_count": len(candidates),
+        "midi_count": len(candidates),
+        "wav_count": len(candidates),
+        "quality_proxy_pass_count": _int(rubric_aggregate.get("quality_proxy_pass_count")),
+        "quality_proxy_fail_count": _int(rubric_aggregate.get("quality_proxy_fail_count")),
+        "major_label_counts": _dict(rubric_aggregate.get("major_label_counts")),
+        "watch_label_counts": _dict(rubric_aggregate.get("watch_label_counts")),
+        "dead_air_range": _range(dead_air),
+        "direction_change_range": _range(direction),
+        "syncopation_range": _range(syncopation),
+        "tension_range": _range(tension),
+        "checksum_mismatch_count": 0,
+        "missing_file_count": 0,
+    }
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_reports": {
+            "source_package": {
+                "schema_version": source_package.get("schema_version"),
+                "output_dir": source_package.get("output_dir"),
+            },
+            "rubric_report": {
+                "schema_version": rubric_report.get("schema_version"),
+                "output_dir": rubric_report.get("output_dir"),
+            },
+            "feasibility_decision": {
+                "schema_version": feasibility_decision.get("schema_version"),
+                "output_dir": feasibility_decision.get("output_dir"),
+            },
+        },
+        "aggregate": aggregate,
+        "candidate_handoff": candidates,
+        "review_input_template": review_input_template,
+        "residual_context": {
+            "tension_repeat_feasible": bool(feasibility.get("tension_repeat_feasible", True)),
+            "tension_repeat_blocked_cases": _list(feasibility.get("tension_repeat_blocked_cases")),
+            "selected_repair_target_from_rubric": _dict(rubric_report.get("decision")).get(
+                "selected_repair_target"
+            ),
+            "residual_major_labels": _dict(rubric_aggregate.get("major_label_counts")),
+            "residual_watch_labels": _dict(rubric_aggregate.get("watch_label_counts")),
+        },
+        "readiness": {
+            "residual_aware_final_review_package_ready": True,
+            "candidate_midi_files_validated": len(candidates),
+            "candidate_wav_files_validated": len(candidates),
+            "review_input_template_written": True,
+            "validated_listening_input_present": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": "music_transformer_solo_yield_residual_aware_final_review_package",
+            "next_boundary": "music_transformer_solo_yield_residual_aware_listening_input_guard",
+            "critical_user_input_required": False,
+            "reason": "objective repair loop reached residual tension blocked by guard; package candidates for listening review without quality claim",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "residual_tension_resolved",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "residual_aware_final_review_package.json", report)
+    write_json(output_dir / "residual_aware_review_input_template.json", review_input_template)
+    write_text(output_dir / "residual_aware_final_review_package.md", markdown_report(report))
+    return report
+
+
+def validate_final_review_package(
+    report: dict[str, Any],
+    *,
+    min_candidate_count: int,
+    require_residual_context: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    if str(report.get("schema_version")) != SCHEMA_VERSION:
+        raise SoloYieldResidualAwareFinalReviewPackageError("schema version mismatch")
+    aggregate = _dict(report.get("aggregate"))
+    readiness = _dict(report.get("readiness"))
+    if _int(aggregate.get("candidate_count")) < int(min_candidate_count):
+        raise SoloYieldResidualAwareFinalReviewPackageError("candidate count below requirement")
+    if _int(aggregate.get("checksum_mismatch_count")):
+        raise SoloYieldResidualAwareFinalReviewPackageError("checksum mismatch found")
+    if _int(aggregate.get("missing_file_count")):
+        raise SoloYieldResidualAwareFinalReviewPackageError("missing file found")
+    residual = _dict(report.get("residual_context"))
+    if require_residual_context and not residual:
+        raise SoloYieldResidualAwareFinalReviewPackageError("residual context required")
+    if require_no_quality_claim:
+        claimed = [
+            key
+            for key in ("musical_quality_claimed", "artist_style_claimed", "production_ready_claimed")
+            if bool(readiness.get(key, True))
+        ]
+        if claimed:
+            raise SoloYieldResidualAwareFinalReviewPackageError(
+                f"unexpected quality claim: {claimed}"
+            )
+    return {
+        "schema_version": str(report.get("schema_version")),
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "midi_count": _int(aggregate.get("midi_count")),
+        "wav_count": _int(aggregate.get("wav_count")),
+        "quality_proxy_pass_count": _int(aggregate.get("quality_proxy_pass_count")),
+        "quality_proxy_fail_count": _int(aggregate.get("quality_proxy_fail_count")),
+        "major_label_counts": _dict(aggregate.get("major_label_counts")),
+        "watch_label_counts": _dict(aggregate.get("watch_label_counts")),
+        "tension_repeat_feasible": bool(residual.get("tension_repeat_feasible", True)),
+        "validated_listening_input_present": bool(readiness.get("validated_listening_input_present", True)),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+        "next_boundary": str(_dict(report.get("decision")).get("next_boundary") or ""),
+    }
+
+
+def _format_counts(value: dict[str, Any]) -> str:
+    if not value:
+        return "none"
+    return ", ".join(f"{key}={value[key]}" for key in sorted(value))
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    residual = report["residual_context"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Music Transformer Solo Yield Residual-Aware Final Review Package",
+        "",
+        "## Summary",
+        "",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- MIDI/WAV: `{aggregate['midi_count']}` / `{aggregate['wav_count']}`",
+        f"- quality proxy pass/fail: `{aggregate['quality_proxy_pass_count']}` / `{aggregate['quality_proxy_fail_count']}`",
+        f"- residual major labels: `{_format_counts(aggregate['major_label_counts'])}`",
+        f"- residual watch labels: `{_format_counts(aggregate['watch_label_counts'])}`",
+        f"- tension repeat feasible: `{_bool_token(residual['tension_repeat_feasible'])}`",
+        f"- tension repeat blocked cases: `{', '.join(residual['tension_repeat_blocked_cases']) or 'none'}`",
+        f"- review input template written: `{_bool_token(readiness['review_input_template_written'])}`",
+        f"- validated listening input present: `{_bool_token(readiness['validated_listening_input_present'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Candidate Handoff",
+        "",
+        "| idx | case | MIDI | WAV | major labels | watch labels |",
+        "|---:|---|---|---|---|---|",
+    ]
+    for row in report.get("candidate_handoff", []):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(row["review_index"]),
+                    f"`{row['case_label']}`",
+                    f"`{row['review_midi_path']}`",
+                    f"`{row['review_wav_path']}`",
+                    f"`{','.join(row['rubric_major_labels']) or 'none'}`",
+                    f"`{','.join(row['rubric_watch_labels']) or 'none'}`",
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build residual-aware final review package")
+    parser.add_argument("--source_package", type=str, required=True)
+    parser.add_argument("--rubric_report", type=str, required=True)
+    parser.add_argument("--feasibility_decision", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_review",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--min_candidate_count", type=int, default=8)
+    parser.add_argument("--require_residual_context", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_final_review_package(
+        source_package=read_json(Path(args.source_package)),
+        rubric_report=read_json(Path(args.rubric_report)),
+        feasibility_decision=read_json(Path(args.feasibility_decision)),
+        output_dir=output_dir,
+    )
+    summary = validate_final_review_package(
+        report,
+        min_candidate_count=int(args.min_candidate_count),
+        require_residual_context=bool(args.require_residual_context),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "residual_aware_final_review_package_summary.json", summary)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_residual_aware_final_review_package.py
+++ b/tests/test_music_transformer_solo_yield_residual_aware_final_review_package.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_music_transformer_solo_yield_residual_aware_final_review_package import (
+    SoloYieldResidualAwareFinalReviewPackageError,
+    build_final_review_package,
+    validate_final_review_package,
+)
+from scripts.render_stage_b_midi_to_solo_candidate_audio import sha256_file
+
+
+def write_file(path: Path, content: bytes) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return sha256_file(path)
+
+
+def source_package(temp_dir: Path, *, quality_claim: bool = False) -> dict:
+    midi_path = temp_dir / "midi" / "candidate_01.mid"
+    wav_path = temp_dir / "audio" / "candidate_01.wav"
+    midi_sha = write_file(midi_path, b"midi")
+    wav_sha = write_file(wav_path, b"wav")
+    return {
+        "schema_version": "music_transformer_solo_yield_rhythm_syncopation_balance_repair_package_v1",
+        "output_dir": "outputs/source_package",
+        "selected_candidates": [
+            {
+                "repair_index": 1,
+                "case_label": "minor_backdoor",
+                "sample_index": 9,
+                "sample_seed": 1009,
+                "repair_midi_path": str(midi_path),
+                "repair_midi_sha256": midi_sha,
+                "note_count": 32,
+                "dead_air_ratio": 0.64,
+                "direction_change_ratio": 0.50,
+                "syncopated_onset_ratio": 0.86,
+                "chord_tone_ratio": 0.44,
+                "tension_ratio": 0.16,
+            }
+        ],
+        "rendered_audio_files": [
+            {
+                "repair_index": 1,
+                "wav_file": {
+                    "path": str(wav_path),
+                    "sha256": wav_sha,
+                    "duration_seconds": 1.25,
+                    "sample_rate": 44100,
+                },
+            }
+        ],
+        "readiness": {
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def rubric_report() -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_objective_quality_rubric_baseline_v1",
+        "output_dir": "outputs/rubric",
+        "candidate_labels": [
+            {
+                "review_index": 1,
+                "major_labels": ["low_tension_color"],
+                "watch_labels": [],
+                "quality_proxy_pass": False,
+            }
+        ],
+        "aggregate": {
+            "candidate_count": 1,
+            "quality_proxy_pass_count": 0,
+            "quality_proxy_fail_count": 1,
+            "major_label_counts": {"low_tension_color": 1},
+            "watch_label_counts": {},
+        },
+        "decision": {
+            "selected_repair_target": "tension_color_balance_repair",
+        },
+        "readiness": {
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def feasibility_decision() -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_residual_tension_target_decision_v1",
+        "output_dir": "outputs/decision",
+        "decision": {
+            "tension_repeat_feasible": False,
+            "tension_repeat_blocked_cases": ["minor_backdoor"],
+        },
+        "readiness": {
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldResidualAwareFinalReviewPackageTest(unittest.TestCase):
+    def test_builds_final_review_package_with_residual_context(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            report = build_final_review_package(
+                source_package=source_package(temp_dir),
+                rubric_report=rubric_report(),
+                feasibility_decision=feasibility_decision(),
+                output_dir=temp_dir / "final",
+            )
+        summary = validate_final_review_package(
+            report,
+            min_candidate_count=1,
+            require_residual_context=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["midi_count"], 1)
+        self.assertEqual(summary["wav_count"], 1)
+        self.assertEqual(summary["major_label_counts"]["low_tension_color"], 1)
+        self.assertFalse(summary["tension_repeat_feasible"])
+        self.assertFalse(summary["validated_listening_input_present"])
+        self.assertFalse(summary["musical_quality_claimed"])
+        self.assertEqual(
+            report["review_input_template"]["schema_version"],
+            "music_transformer_solo_yield_residual_aware_review_input_v1",
+        )
+
+    def test_rejects_checksum_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+            package = source_package(temp_dir)
+            package["selected_candidates"][0]["repair_midi_sha256"] = "bad"
+
+            with self.assertRaises(SoloYieldResidualAwareFinalReviewPackageError):
+                build_final_review_package(
+                    source_package=package,
+                    rubric_report=rubric_report(),
+                    feasibility_decision=feasibility_decision(),
+                    output_dir=temp_dir / "final",
+                )
+
+    def test_rejects_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp_dir = Path(raw_temp)
+
+            with self.assertRaises(SoloYieldResidualAwareFinalReviewPackageError):
+                build_final_review_package(
+                    source_package=source_package(temp_dir, quality_claim=True),
+                    rubric_report=rubric_report(),
+                    feasibility_decision=feasibility_decision(),
+                    output_dir=temp_dir / "final",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- residual-aware final review package 추가
- #1384 candidate MIDI/WAV 8개 checksum 검증
- #1386 rubric label과 #1382 feasibility context 연결
- pending review input template 생성

## Context

- #1384 package: MIDI/WAV `8/8`, syncopation low count `1 -> 0`, tension low count `2 -> 2`
- #1386 rubric: quality proxy pass/fail `6/2`, residual major label `low_tension_color=2`, watch label `dead_air_watch=3`
- #1382 feasibility: tension repeat feasible `false`, blocked cases `minor_backdoor`, `major_ii_v_turnaround`

## Scope

- final review adapter script
- checksum validation for final MIDI/WAV handoff
- residual context attachment
- review input template output
- summary document

## Result

- candidate count: `8`
- MIDI/WAV: `8` / `8`
- quality proxy pass/fail: `6` / `2`
- residual major labels: `low_tension_color=2`
- residual watch labels: `dead_air_watch=3`
- tension repeat feasible: `false`
- validated listening input present: `false`

## Validation

- `.venv/bin/python -m py_compile scripts/build_music_transformer_solo_yield_residual_aware_final_review_package.py tests/test_music_transformer_solo_yield_residual_aware_final_review_package.py`
- `.venv/bin/python -m unittest tests.test_music_transformer_solo_yield_residual_aware_final_review_package`
- `.venv/bin/python scripts/build_music_transformer_solo_yield_residual_aware_final_review_package.py --run_id issue_1388_residual_aware_final_review_package --source_package outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/rhythm_syncopation_balance_repair_package.json --rubric_report outputs/music_transformer_finetune_mvp/solo_yield_objective_quality_rubric/issue_1386_rhythm_syncopation_repair_rubric_review/objective_quality_rubric_baseline.json --feasibility_decision outputs/music_transformer_finetune_mvp/solo_yield_residual_tension_decision/issue_1382_residual_tension_feasibility_decision/residual_tension_target_decision.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_REVIEW_PACKAGE_2026-06-11.md --min_candidate_count 8 --require_residual_context --require_no_quality_claim`
- public artifact tool-name scan: no matches
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- listening preference not inferred
- residual low tension remains accepted as constrained risk
- generated output artifacts remain local

## Follow-up

- residual-aware listening input guard
- README/current status sync

Closes #1388