### PR TITLE
Stage B MIDI-to-solo residual-aware MVP handoff freeze

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - rhythm syncopation repair: syncopation avg `0.7951 -> 0.8160`, low count `1 -> 0`
 - residual-aware final review package: candidate `8`, MIDI/WAV `8 / 8`, proxy pass/fail `6 / 2`
 - residual-aware listening input guard: preference fill `false`, listening review completed `false`
+- residual-aware MVP handoff freeze: local artifacts verified `true`, checksum mismatch `0`
 
 ## 최신 산출물
 
@@ -50,6 +51,7 @@
 - WAV 후보: `outputs/music_transformer_finetune_mvp/solo_yield_rhythm_syncopation_balance_repair/issue_1384_rhythm_syncopation_balance_repair_package/audio/`
 - final review doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_REVIEW_PACKAGE_2026-06-11.md`
 - listening input guard doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_INPUT_GUARD_2026-06-11.md`
+- MVP handoff freeze doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_MVP_HANDOFF_FREEZE_2026-06-11.md`
 
 ## 재현 명령
 
@@ -73,6 +75,18 @@
   --require_no_quality_claim
 ```
 
+```bash
+.venv/bin/python scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py \
+  --run_id issue_1396_residual_aware_mvp_handoff_freeze \
+  --final_review_package outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_review/issue_1388_residual_aware_final_review_package/residual_aware_final_review_package.json \
+  --input_guard_report outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_listening_input_guard/issue_1390_residual_aware_listening_input_guard/residual_aware_listening_input_guard.json \
+  --status_audit_report outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_status_audit/issue_1394_residual_aware_status_audit/residual_aware_status_audit.json \
+  --expected_next_boundary music_transformer_solo_yield_residual_aware_listening_review_pending \
+  --require_local_artifacts_verified \
+  --require_pending_input \
+  --require_no_quality_claim
+```
+
 ## 아닌 것
 
 - 완성형 jazz solo quality claim 아님
@@ -86,7 +100,9 @@
 - `scripts/build_music_transformer_solo_yield_rhythm_syncopation_balance_repair_package.py`
 - `scripts/build_music_transformer_solo_yield_residual_aware_final_review_package.py`
 - `scripts/guard_music_transformer_solo_yield_residual_aware_listening_input.py`
+- `scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py`
 - `scripts/build_music_transformer_solo_yield_objective_quality_rubric_baseline.py`
 - `scripts/decide_music_transformer_solo_yield_residual_tension_target.py`
 - `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_REVIEW_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_INPUT_GUARD_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_MVP_HANDOFF_FREEZE_2026-06-11.md`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -13538,6 +13538,53 @@ Issue #1394는 #1388 residual-aware final review package, #1390 listening input 
 
 - `Stage B MIDI-to-solo residual-aware MVP handoff freeze`
 
+## 9.247 Stage B MIDI-to-solo residual-aware MVP handoff freeze
+
+Issue #1396은 #1388 final review package, #1390 input guard, #1394 status audit를 기준으로 로컬 MVP handoff를 고정한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_MVP_HANDOFF_FREEZE_2026-06-11.md`
+- output: `outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_mvp_handoff_freeze/issue_1396_residual_aware_mvp_handoff_freeze/`
+- boundary: `music_transformer_solo_yield_residual_aware_mvp_handoff_freeze`
+- source final review schema: `music_transformer_solo_yield_residual_aware_final_review_package_v1`
+- source input guard schema: `music_transformer_solo_yield_residual_aware_listening_input_guard_v1`
+- source status audit schema: `music_transformer_solo_yield_residual_aware_status_audit_v1`
+- candidate count: `8`
+- MIDI/WAV: `8 / 8`
+- quality proxy pass/fail: `6 / 2`
+- residual major label: `low_tension_color=2`
+- residual watch label: `dead_air_watch=3`
+- local candidate artifacts verified: `true`
+- missing file count: `0`
+- checksum mismatch count: `0`
+- missing support file count: `0`
+- review input template available: `true`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- listening review completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- raw artifact upload required: `false`
+- next boundary: `music_transformer_solo_yield_residual_aware_listening_review_pending`
+
+판단:
+
+- final review package candidate manifest의 MIDI/WAV 경로와 SHA-256 재검증 완료.
+- review package, review input template, status audit 연결 경로 보존.
+- raw MIDI/WAV 업로드 없이 로컬 산출물 경로와 checksum 기준으로 handoff freeze 정의.
+- listening input pending 상태에서 preference fill과 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_music_transformer_solo_yield_residual_aware_mvp_handoff_freeze`
+- `.venv/bin/python -m py_compile scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py tests/test_music_transformer_solo_yield_residual_aware_mvp_handoff_freeze.py`
+- `.venv/bin/python scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py --run_id issue_1396_residual_aware_mvp_handoff_freeze --issue_number 1396 --final_review_package outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_review/issue_1388_residual_aware_final_review_package/residual_aware_final_review_package.json --input_guard_report outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_listening_input_guard/issue_1390_residual_aware_listening_input_guard/residual_aware_listening_input_guard.json --status_audit_report outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_status_audit/issue_1394_residual_aware_status_audit/residual_aware_status_audit.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_MVP_HANDOFF_FREEZE_2026-06-11.md --expected_next_boundary music_transformer_solo_yield_residual_aware_listening_review_pending --require_local_artifacts_verified --require_pending_input --require_no_quality_claim`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo residual-aware listening review pending boundary`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -15,9 +15,10 @@
 - latest residual-aware final review package: Issue #1388, Stage B MIDI-to-solo residual-aware final review package
 - latest residual-aware listening input guard: Issue #1390, Stage B MIDI-to-solo residual-aware listening input guard
 - latest residual-aware README/status sync: Issue #1392, Stage B MIDI-to-solo residual-aware README and status sync
-- current issue: Issue #1394, Stage B MIDI-to-solo residual-aware status audit
+- latest residual-aware status audit: Issue #1394, Stage B MIDI-to-solo residual-aware status audit
+- current issue: Issue #1396, Stage B MIDI-to-solo residual-aware MVP handoff freeze
 - open issue queue after residual-aware listening input guard merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware MVP handoff freeze`
+- 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware listening review pending boundary`
 
 현재 범위가 아닌 것:
 
@@ -47,6 +48,10 @@
 - residual-aware status audit synced: `true`
 - residual-aware status audit README/current status missing snippet: `0 / 0`
 - residual-aware status audit next boundary: `music_transformer_solo_yield_residual_aware_mvp_handoff_freeze`
+- residual-aware MVP handoff freeze local artifacts verified: `true`
+- residual-aware MVP handoff freeze missing/checksum mismatch: `0 / 0`
+- residual-aware MVP handoff freeze raw artifact upload required: `false`
+- residual-aware MVP handoff freeze next boundary: `music_transformer_solo_yield_residual_aware_listening_review_pending`
 - broader repaired sampling audit strict/grammar: `40 / 40` / `40 / 40`
 - broader repaired review package MIDI/WAV: `8 / 8`
 - broader repaired final handoff selected objective candidates: `4`

--- a/docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_MVP_HANDOFF_FREEZE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_MVP_HANDOFF_FREEZE_2026-06-11.md
@@ -1,0 +1,34 @@
+# Music Transformer Solo Yield Residual-Aware MVP Handoff Freeze
+
+## Summary
+
+- issue: `#1396`
+- candidate count: `8`
+- MIDI/WAV: `8` / `8`
+- quality proxy pass/fail: `6` / `2`
+- major labels: `low_tension_color=2`
+- watch labels: `dead_air_watch=3`
+- local candidate artifacts verified: `true`
+- missing file count: `0`
+- checksum mismatch count: `0`
+- review input template available: `true`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- listening review completed: `false`
+- musical quality claimed: `false`
+- raw artifact upload required: `false`
+- next boundary: `music_transformer_solo_yield_residual_aware_listening_review_pending`
+
+## Artifact Paths
+
+- final_review_package_json: `outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_review/issue_1388_residual_aware_final_review_package/residual_aware_final_review_package.json`
+- final_review_package_md: `outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_review/issue_1388_residual_aware_final_review_package/residual_aware_final_review_package.md`
+- review_input_template_json: `outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_review/issue_1388_residual_aware_final_review_package/residual_aware_review_input_template.json`
+
+## Not Proven
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `stable_jazz_solo_quality`
+- `production_ready_improviser`

--- a/scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py
+++ b/scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py
@@ -1,0 +1,471 @@
+"""Freeze residual-aware local MVP handoff for solo-yield candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import sha256_file  # noqa: E402
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_mvp_handoff_freeze_v1"
+FINAL_REVIEW_SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_final_review_package_v1"
+INPUT_GUARD_SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_listening_input_guard_v1"
+STATUS_AUDIT_SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_status_audit_v1"
+BOUNDARY = "music_transformer_solo_yield_residual_aware_mvp_handoff_freeze"
+NEXT_BOUNDARY = "music_transformer_solo_yield_residual_aware_listening_review_pending"
+
+
+class SoloYieldResidualAwareMvpHandoffFreezeError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _format_counts(value: dict[str, Any]) -> str:
+    if not value:
+        return "none"
+    return ", ".join(f"{key}={value[key]}" for key in sorted(value))
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldResidualAwareMvpHandoffFreezeError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_file(path_value: Any, *, label: str) -> Path:
+    path = Path(str(path_value or ""))
+    if not str(path) or not path.exists() or not path.is_file():
+        raise SoloYieldResidualAwareMvpHandoffFreezeError(f"{label} missing: {path}")
+    return path
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [
+        key
+        for key in (
+            "human_audio_preference_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "musical_quality_claimed",
+            "artist_style_claimed",
+            "production_ready_claimed",
+        )
+        if bool(container.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def _require_checksum(path: Path, expected: str, *, label: str) -> None:
+    actual = sha256_file(path)
+    if str(expected or "") != actual:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError(
+            f"{label} checksum mismatch: expected={expected} actual={actual}"
+        )
+
+
+def validate_status_audit(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != STATUS_AUDIT_SCHEMA_VERSION:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("status audit schema mismatch")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    if not bool(readiness.get("residual_aware_status_audit_completed", False)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("status audit completion required")
+    if not bool(readiness.get("residual_aware_status_synced", False)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("status sync required before freeze")
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("status audit must route to handoff freeze")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("critical user input should not be required")
+    _require_no_quality_claim(readiness, label="status audit readiness")
+    return {
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "midi_count": _int(aggregate.get("midi_count")),
+        "wav_count": _int(aggregate.get("wav_count")),
+        "quality_proxy_pass_count": _int(aggregate.get("quality_proxy_pass_count")),
+        "quality_proxy_fail_count": _int(aggregate.get("quality_proxy_fail_count")),
+        "validated_listening_input_present": bool(
+            readiness.get("validated_listening_input_present", True)
+        ),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "listening_review_completed": bool(readiness.get("listening_review_completed", True)),
+    }
+
+
+def validate_final_review_package(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != FINAL_REVIEW_SCHEMA_VERSION:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("final review schema mismatch")
+    aggregate = _dict(report.get("aggregate"))
+    readiness = _dict(report.get("readiness"))
+    candidates = _list(report.get("candidate_handoff"))
+    candidate_count = _int(aggregate.get("candidate_count"))
+    if not bool(readiness.get("residual_aware_final_review_package_ready", False)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("final review readiness required")
+    if candidate_count <= 0 or len(candidates) != candidate_count:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("candidate handoff count mismatch")
+    if _int(aggregate.get("midi_count")) != candidate_count:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("MIDI count mismatch")
+    if _int(aggregate.get("wav_count")) != candidate_count:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("WAV count mismatch")
+    if _int(aggregate.get("missing_file_count")) != 0:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("missing file count must be zero")
+    if _int(aggregate.get("checksum_mismatch_count")) != 0:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("checksum mismatch count must be zero")
+    _require_no_quality_claim(readiness, label="final review readiness")
+    return {
+        "candidate_count": candidate_count,
+        "midi_count": _int(aggregate.get("midi_count")),
+        "wav_count": _int(aggregate.get("wav_count")),
+        "quality_proxy_pass_count": _int(aggregate.get("quality_proxy_pass_count")),
+        "quality_proxy_fail_count": _int(aggregate.get("quality_proxy_fail_count")),
+        "major_label_counts": _dict(aggregate.get("major_label_counts")),
+        "watch_label_counts": _dict(aggregate.get("watch_label_counts")),
+        "output_dir": str(report.get("output_dir") or ""),
+    }
+
+
+def validate_input_guard(report: dict[str, Any], *, expected_candidate_count: int) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != INPUT_GUARD_SCHEMA_VERSION:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("input guard schema mismatch")
+    guard = _dict(report.get("guard_result"))
+    readiness = _dict(report.get("readiness"))
+    if not bool(readiness.get("residual_aware_listening_input_guard_completed", False)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("input guard completion required")
+    if _int(guard.get("review_item_count")) != expected_candidate_count:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("review item count mismatch")
+    _require_no_quality_claim(readiness, label="input guard readiness")
+    return {
+        "review_item_count": _int(guard.get("review_item_count")),
+        "validated_listening_input_present": bool(guard.get("validated_listening_input_present", True)),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", True)),
+        "listening_review_completed": bool(readiness.get("listening_review_completed", True)),
+        "output_dir": str(report.get("output_dir") or ""),
+    }
+
+
+def _handoff_support_paths(final_review_package: dict[str, Any]) -> dict[str, str]:
+    output_dir = Path(str(final_review_package.get("output_dir") or ""))
+    return {
+        "final_review_package_md": str(output_dir / "residual_aware_final_review_package.md"),
+        "final_review_package_json": str(output_dir / "residual_aware_final_review_package.json"),
+        "review_input_template_json": str(output_dir / "residual_aware_review_input_template.json"),
+    }
+
+
+def build_candidate_manifest(final_review_package: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for candidate in _list(final_review_package.get("candidate_handoff")):
+        item = _dict(candidate)
+        midi_path = _require_file(item.get("review_midi_path"), label="candidate MIDI")
+        wav_path = _require_file(item.get("review_wav_path"), label="candidate WAV")
+        midi_sha = str(item.get("review_midi_sha256") or "")
+        wav_sha = str(item.get("review_wav_sha256") or "")
+        _require_checksum(midi_path, midi_sha, label="MIDI")
+        _require_checksum(wav_path, wav_sha, label="WAV")
+        rows.append(
+            {
+                "review_index": _int(item.get("review_index")),
+                "case_label": str(item.get("case_label") or ""),
+                "sample_index": _int(item.get("sample_index")),
+                "sample_seed": _int(item.get("sample_seed")),
+                "review_midi_path": str(midi_path),
+                "review_wav_path": str(wav_path),
+                "review_midi_sha256": midi_sha,
+                "review_wav_sha256": wav_sha,
+                "duration_seconds": _float(item.get("duration_seconds")),
+                "sample_rate": _int(item.get("sample_rate")),
+                "quality_proxy_pass": bool(item.get("quality_proxy_pass", False)),
+                "rubric_major_labels": _list(item.get("rubric_major_labels")),
+                "rubric_watch_labels": _list(item.get("rubric_watch_labels")),
+            }
+        )
+    return rows
+
+
+def _verify_support_paths(paths: dict[str, str]) -> dict[str, Any]:
+    missing = [path for path in paths.values() if not Path(path).exists()]
+    return {
+        "support_file_count": len(paths),
+        "missing_support_files": missing,
+        "support_files_verified": not missing,
+    }
+
+
+def build_handoff_freeze_report(
+    *,
+    final_review_package: dict[str, Any],
+    input_guard_report: dict[str, Any],
+    status_audit_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    status = validate_status_audit(status_audit_report)
+    final_summary = validate_final_review_package(final_review_package)
+    guard_summary = validate_input_guard(
+        input_guard_report,
+        expected_candidate_count=int(final_summary["candidate_count"]),
+    )
+    candidates = build_candidate_manifest(final_review_package)
+    support_paths = _handoff_support_paths(final_review_package)
+    support_validation = _verify_support_paths(support_paths)
+    counts_match = bool(
+        status["candidate_count"]
+        == final_summary["candidate_count"]
+        == guard_summary["review_item_count"]
+        == len(candidates)
+        and status["midi_count"] == final_summary["midi_count"]
+        and status["wav_count"] == final_summary["wav_count"]
+    )
+    pending_input = not bool(guard_summary["validated_listening_input_present"])
+    preference_blocked = not bool(guard_summary["preference_fill_allowed"])
+    local_artifacts_verified = bool(
+        counts_match
+        and support_validation["support_files_verified"]
+        and len(candidates) == int(final_summary["candidate_count"])
+    )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "source_reports": {
+            "final_review_package": final_review_package.get("output_dir"),
+            "input_guard_report": input_guard_report.get("output_dir"),
+            "status_audit_report": status_audit_report.get("output_dir"),
+        },
+        "artifact_paths": support_paths,
+        "aggregate": {
+            "candidate_count": len(candidates),
+            "midi_count": final_summary["midi_count"],
+            "wav_count": final_summary["wav_count"],
+            "review_item_count": guard_summary["review_item_count"],
+            "quality_proxy_pass_count": final_summary["quality_proxy_pass_count"],
+            "quality_proxy_fail_count": final_summary["quality_proxy_fail_count"],
+            "major_label_counts": final_summary["major_label_counts"],
+            "watch_label_counts": final_summary["watch_label_counts"],
+            "missing_file_count": 0,
+            "checksum_mismatch_count": 0,
+            "missing_support_file_count": len(support_validation["missing_support_files"]),
+            "counts_match": counts_match,
+            "raw_artifact_upload_required": False,
+        },
+        "candidate_manifest": candidates,
+        "support_file_validation": support_validation,
+        "readiness": {
+            "residual_aware_mvp_handoff_freeze_completed": True,
+            "local_candidate_artifacts_verified": local_artifacts_verified,
+            "review_input_template_available": Path(
+                support_paths["review_input_template_json"]
+            ).exists(),
+            "validated_listening_input_present": pending_input is False,
+            "preference_fill_allowed": preference_blocked is False,
+            "listening_review_completed": bool(guard_summary["listening_review_completed"]),
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+            "reason": "local MVP candidate handoff frozen; listening review input remains pending",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "stable_jazz_solo_quality",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "residual_aware_mvp_handoff_freeze.json", report)
+    write_json(
+        output_dir / "residual_aware_mvp_handoff_freeze_summary.json",
+        validate_handoff_freeze_report(report),
+    )
+    write_text(output_dir / "residual_aware_mvp_handoff_freeze.md", markdown_report(report))
+    return report
+
+
+def validate_handoff_freeze_report(
+    report: dict[str, Any],
+    *,
+    expected_next_boundary: str | None = None,
+    require_local_artifacts_verified: bool = False,
+    require_pending_input: bool = False,
+    require_no_quality_claim: bool = False,
+) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("handoff freeze schema mismatch")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    if not bool(readiness.get("residual_aware_mvp_handoff_freeze_completed", False)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("handoff freeze completion required")
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("unexpected next boundary")
+    if require_local_artifacts_verified and not bool(
+        readiness.get("local_candidate_artifacts_verified", False)
+    ):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("local candidate artifacts verification required")
+    if require_pending_input and bool(readiness.get("validated_listening_input_present", True)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("validated listening input should remain pending")
+    if require_pending_input and bool(readiness.get("preference_fill_allowed", True)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("preference fill should remain blocked")
+    if require_pending_input and bool(readiness.get("listening_review_completed", True)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("listening review should remain pending")
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="handoff freeze readiness")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise SoloYieldResidualAwareMvpHandoffFreezeError("critical user input should not be required")
+    return {
+        "schema_version": str(report.get("schema_version")),
+        "local_candidate_artifacts_verified": bool(
+            readiness.get("local_candidate_artifacts_verified", False)
+        ),
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "midi_count": _int(aggregate.get("midi_count")),
+        "wav_count": _int(aggregate.get("wav_count")),
+        "quality_proxy_pass_count": _int(aggregate.get("quality_proxy_pass_count")),
+        "quality_proxy_fail_count": _int(aggregate.get("quality_proxy_fail_count")),
+        "missing_file_count": _int(aggregate.get("missing_file_count")),
+        "checksum_mismatch_count": _int(aggregate.get("checksum_mismatch_count")),
+        "missing_support_file_count": _int(aggregate.get("missing_support_file_count")),
+        "validated_listening_input_present": bool(
+            readiness.get("validated_listening_input_present", True)
+        ),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "listening_review_completed": bool(readiness.get("listening_review_completed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "raw_artifact_upload_required": bool(aggregate.get("raw_artifact_upload_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Music Transformer Solo Yield Residual-Aware MVP Handoff Freeze",
+        "",
+        "## Summary",
+        "",
+        f"- issue: `#{report['issue_number']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- MIDI/WAV: `{aggregate['midi_count']}` / `{aggregate['wav_count']}`",
+        (
+            "- quality proxy pass/fail: "
+            f"`{aggregate['quality_proxy_pass_count']}` / `{aggregate['quality_proxy_fail_count']}`"
+        ),
+        f"- major labels: `{_format_counts(aggregate['major_label_counts'])}`",
+        f"- watch labels: `{_format_counts(aggregate['watch_label_counts'])}`",
+        f"- local candidate artifacts verified: `{_bool_token(readiness['local_candidate_artifacts_verified'])}`",
+        f"- missing file count: `{aggregate['missing_file_count']}`",
+        f"- checksum mismatch count: `{aggregate['checksum_mismatch_count']}`",
+        f"- review input template available: `{_bool_token(readiness['review_input_template_available'])}`",
+        f"- validated listening input present: `{_bool_token(readiness['validated_listening_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(readiness['preference_fill_allowed'])}`",
+        f"- listening review completed: `{_bool_token(readiness['listening_review_completed'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        f"- raw artifact upload required: `{_bool_token(aggregate['raw_artifact_upload_required'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Artifact Paths",
+        "",
+    ]
+    for name, path in sorted(report["artifact_paths"].items()):
+        lines.append(f"- {name}: `{path}`")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Freeze residual-aware local MVP handoff")
+    parser.add_argument("--final_review_package", type=str, required=True)
+    parser.add_argument("--input_guard_report", type=str, required=True)
+    parser.add_argument("--status_audit_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_mvp_handoff_freeze",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=0)
+    parser.add_argument("--expected_next_boundary", type=str, default=NEXT_BOUNDARY)
+    parser.add_argument("--require_local_artifacts_verified", action="store_true")
+    parser.add_argument("--require_pending_input", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_handoff_freeze_report(
+        final_review_package=read_json(Path(args.final_review_package)),
+        input_guard_report=read_json(Path(args.input_guard_report)),
+        status_audit_report=read_json(Path(args.status_audit_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_handoff_freeze_report(
+        report,
+        expected_next_boundary=str(args.expected_next_boundary),
+        require_local_artifacts_verified=bool(args.require_local_artifacts_verified),
+        require_pending_input=bool(args.require_pending_input),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_residual_aware_mvp_handoff_freeze.py
+++ b/tests/test_music_transformer_solo_yield_residual_aware_mvp_handoff_freeze.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.freeze_music_transformer_solo_yield_residual_aware_mvp_handoff import (
+    NEXT_BOUNDARY,
+    SoloYieldResidualAwareMvpHandoffFreezeError,
+    build_handoff_freeze_report,
+    validate_handoff_freeze_report,
+)
+
+
+def sha256_text(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write_file(path: Path, text: str) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return sha256_text(path)
+
+
+def final_review_package(root: Path, *, quality_claim: bool = False, bad_checksum: bool = False) -> dict:
+    output_dir = root / "final_review"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "residual_aware_final_review_package.md").write_text("review", encoding="utf-8")
+    (output_dir / "residual_aware_final_review_package.json").write_text("{}", encoding="utf-8")
+    (output_dir / "residual_aware_review_input_template.json").write_text("{}", encoding="utf-8")
+    midi_sha = write_file(root / "candidate_01.mid", "midi")
+    wav_sha = write_file(root / "candidate_01.wav", "wav")
+    if bad_checksum:
+        midi_sha = "0" * 64
+    return {
+        "schema_version": "music_transformer_solo_yield_residual_aware_final_review_package_v1",
+        "output_dir": str(output_dir),
+        "aggregate": {
+            "candidate_count": 1,
+            "midi_count": 1,
+            "wav_count": 1,
+            "quality_proxy_pass_count": 1,
+            "quality_proxy_fail_count": 0,
+            "major_label_counts": {},
+            "watch_label_counts": {},
+            "missing_file_count": 0,
+            "checksum_mismatch_count": 0,
+        },
+        "candidate_handoff": [
+            {
+                "review_index": 1,
+                "case_label": "unit",
+                "sample_index": 1,
+                "sample_seed": 10,
+                "review_midi_path": str(root / "candidate_01.mid"),
+                "review_wav_path": str(root / "candidate_01.wav"),
+                "review_midi_sha256": midi_sha,
+                "review_wav_sha256": wav_sha,
+                "duration_seconds": 1.0,
+                "sample_rate": 44100,
+                "quality_proxy_pass": True,
+                "rubric_major_labels": [],
+                "rubric_watch_labels": [],
+            }
+        ],
+        "readiness": {
+            "residual_aware_final_review_package_ready": True,
+            "validated_listening_input_present": False,
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def input_guard() -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_residual_aware_listening_input_guard_v1",
+        "output_dir": "outputs/input_guard",
+        "guard_result": {
+            "review_item_count": 1,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+        },
+        "readiness": {
+            "residual_aware_listening_input_guard_completed": True,
+            "listening_review_completed": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def status_audit(*, synced: bool = True) -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_residual_aware_status_audit_v1",
+        "output_dir": "outputs/status_audit",
+        "aggregate": {
+            "candidate_count": 1,
+            "midi_count": 1,
+            "wav_count": 1,
+            "quality_proxy_pass_count": 1,
+            "quality_proxy_fail_count": 0,
+        },
+        "readiness": {
+            "residual_aware_status_audit_completed": True,
+            "residual_aware_status_synced": synced,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "listening_review_completed": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "music_transformer_solo_yield_residual_aware_mvp_handoff_freeze",
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldResidualAwareMvpHandoffFreezeTest(unittest.TestCase):
+    def test_builds_handoff_freeze_with_verified_local_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            root = Path(raw_temp)
+            report = build_handoff_freeze_report(
+                final_review_package=final_review_package(root),
+                input_guard_report=input_guard(),
+                status_audit_report=status_audit(),
+                output_dir=root / "handoff",
+                issue_number=1396,
+            )
+        summary = validate_handoff_freeze_report(
+            report,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_local_artifacts_verified=True,
+            require_pending_input=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["local_candidate_artifacts_verified"])
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["midi_count"], 1)
+        self.assertEqual(summary["wav_count"], 1)
+        self.assertEqual(summary["checksum_mismatch_count"], 0)
+        self.assertFalse(summary["validated_listening_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertFalse(summary["raw_artifact_upload_required"])
+
+    def test_rejects_unsynced_status_audit(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            root = Path(raw_temp)
+            with self.assertRaises(SoloYieldResidualAwareMvpHandoffFreezeError):
+                build_handoff_freeze_report(
+                    final_review_package=final_review_package(root),
+                    input_guard_report=input_guard(),
+                    status_audit_report=status_audit(synced=False),
+                    output_dir=root / "handoff",
+                    issue_number=1396,
+                )
+
+    def test_rejects_candidate_checksum_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            root = Path(raw_temp)
+            with self.assertRaises(SoloYieldResidualAwareMvpHandoffFreezeError):
+                build_handoff_freeze_report(
+                    final_review_package=final_review_package(root, bad_checksum=True),
+                    input_guard_report=input_guard(),
+                    status_audit_report=status_audit(),
+                    output_dir=root / "handoff",
+                    issue_number=1396,
+                )
+
+    def test_rejects_quality_claim_in_final_review(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            root = Path(raw_temp)
+            with self.assertRaises(SoloYieldResidualAwareMvpHandoffFreezeError):
+                build_handoff_freeze_report(
+                    final_review_package=final_review_package(root, quality_claim=True),
+                    input_guard_report=input_guard(),
+                    status_audit_report=status_audit(),
+                    output_dir=root / "handoff",
+                    issue_number=1396,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- residual-aware MVP handoff freeze 스크립트 추가
- #1388 candidate manifest MIDI/WAV checksum 재검증
- #1394 status audit 이후 로컬 MVP 산출물 경로 고정
- README / CURRENT_STATUS_AND_PLAN / CORE_PLAN 갱신

## Context
- #1394 status audit: synced true, README/current status missing snippet 0 / 0
- final review package: candidate 8, MIDI/WAV 8 / 8, proxy pass/fail 6 / 2
- residual labels: low_tension_color=2, dead_air_watch=3
- listening input pending, preference fill false, musical quality claim false

## Scope
- scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py
- tests/test_music_transformer_solo_yield_residual_aware_mvp_handoff_freeze.py
- residual-aware MVP handoff freeze markdown 기록
- README/current status/core plan 최신 handoff boundary 반영

## Validation
- public artifact tool-name scan: no matches
- git diff --cached --check
- .venv/bin/python -m unittest tests.test_music_transformer_solo_yield_residual_aware_mvp_handoff_freeze
- .venv/bin/python -m py_compile scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py tests/test_music_transformer_solo_yield_residual_aware_mvp_handoff_freeze.py
- .venv/bin/python scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py --run_id issue_1396_residual_aware_mvp_handoff_freeze --issue_number 1396 --final_review_package outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_review/issue_1388_residual_aware_final_review_package/residual_aware_final_review_package.json --input_guard_report outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_listening_input_guard/issue_1390_residual_aware_listening_input_guard/residual_aware_listening_input_guard.json --status_audit_report outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_status_audit/issue_1394_residual_aware_status_audit/residual_aware_status_audit.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_MVP_HANDOFF_FREEZE_2026-06-11.md --expected_next_boundary music_transformer_solo_yield_residual_aware_listening_review_pending --require_local_artifacts_verified --require_pending_input --require_no_quality_claim
- bash scripts/agent_harness.sh quick

## Risk
- raw MIDI/WAV artifact upload 없음
- musical quality claim 없음
- listening review completed false 유지

Closes #1396