### PR TITLE
Stage B MIDI-to-solo residual-aware listening review pending boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - residual-aware final review package: candidate `8`, MIDI/WAV `8 / 8`, proxy pass/fail `6 / 2`
 - residual-aware listening input guard: preference fill `false`, listening review completed `false`
 - residual-aware MVP handoff freeze: local artifacts verified `true`, checksum mismatch `0`
+- residual-aware listening review pending: pending candidate `8`, quality claim `false`
 
 ## 최신 산출물
 
@@ -52,6 +53,7 @@
 - final review doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_REVIEW_PACKAGE_2026-06-11.md`
 - listening input guard doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_INPUT_GUARD_2026-06-11.md`
 - MVP handoff freeze doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_MVP_HANDOFF_FREEZE_2026-06-11.md`
+- listening review pending doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_PENDING_2026-06-11.md`
 
 ## 재현 명령
 
@@ -87,6 +89,15 @@
   --require_no_quality_claim
 ```
 
+```bash
+.venv/bin/python scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py \
+  --run_id issue_1398_residual_aware_listening_review_pending \
+  --handoff_freeze_report outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_mvp_handoff_freeze/issue_1396_residual_aware_mvp_handoff_freeze/residual_aware_mvp_handoff_freeze.json \
+  --expected_next_boundary music_transformer_solo_yield_residual_aware_completion_audit \
+  --require_pending_review \
+  --require_no_quality_claim
+```
+
 ## 아닌 것
 
 - 완성형 jazz solo quality claim 아님
@@ -101,8 +112,10 @@
 - `scripts/build_music_transformer_solo_yield_residual_aware_final_review_package.py`
 - `scripts/guard_music_transformer_solo_yield_residual_aware_listening_input.py`
 - `scripts/freeze_music_transformer_solo_yield_residual_aware_mvp_handoff.py`
+- `scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py`
 - `scripts/build_music_transformer_solo_yield_objective_quality_rubric_baseline.py`
 - `scripts/decide_music_transformer_solo_yield_residual_tension_target.py`
 - `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_REVIEW_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_MVP_HANDOFF_FREEZE_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_PENDING_2026-06-11.md`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -13585,6 +13585,48 @@ Issue #1396은 #1388 final review package, #1390 input guard, #1394 status audit
 
 - `Stage B MIDI-to-solo residual-aware listening review pending boundary`
 
+## 9.248 Stage B MIDI-to-solo residual-aware listening review pending boundary
+
+Issue #1398은 #1396 handoff freeze 결과를 기준으로 listening review 입력 대기 상태와 quality claim 차단 조건을 고정한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_PENDING_2026-06-11.md`
+- output: `outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_listening_review_pending/issue_1398_residual_aware_listening_review_pending/`
+- boundary: `music_transformer_solo_yield_residual_aware_listening_review_pending`
+- source handoff freeze schema: `music_transformer_solo_yield_residual_aware_mvp_handoff_freeze_v1`
+- review input schema: `music_transformer_solo_yield_residual_aware_review_input_v1`
+- candidate count: `8`
+- MIDI/WAV: `8 / 8`
+- pending candidate count: `8`
+- quality proxy pass/fail: `6 / 2`
+- residual major label: `low_tension_color=2`
+- residual watch label: `dead_air_watch=3`
+- review input template status: `pending`
+- manual review required for quality claim: `true`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- listening review completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_residual_aware_completion_audit`
+
+판단:
+
+- review input template의 candidate 8개가 모두 pending 상태인지 확인.
+- 사용자 청취 입력 없이 preference fill을 채우지 않도록 차단.
+- 기술 MVP completion audit은 진행 가능하되, musical quality claim은 listening review 이후로 제한.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_music_transformer_solo_yield_residual_aware_listening_review_pending`
+- `.venv/bin/python -m py_compile scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py tests/test_music_transformer_solo_yield_residual_aware_listening_review_pending.py`
+- `.venv/bin/python scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py --run_id issue_1398_residual_aware_listening_review_pending --issue_number 1398 --handoff_freeze_report outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_mvp_handoff_freeze/issue_1396_residual_aware_mvp_handoff_freeze/residual_aware_mvp_handoff_freeze.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_PENDING_2026-06-11.md --expected_next_boundary music_transformer_solo_yield_residual_aware_completion_audit --require_pending_review --require_no_quality_claim`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo residual-aware completion audit`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -16,9 +16,10 @@
 - latest residual-aware listening input guard: Issue #1390, Stage B MIDI-to-solo residual-aware listening input guard
 - latest residual-aware README/status sync: Issue #1392, Stage B MIDI-to-solo residual-aware README and status sync
 - latest residual-aware status audit: Issue #1394, Stage B MIDI-to-solo residual-aware status audit
-- current issue: Issue #1396, Stage B MIDI-to-solo residual-aware MVP handoff freeze
+- latest residual-aware MVP handoff freeze: Issue #1396, Stage B MIDI-to-solo residual-aware MVP handoff freeze
+- current issue: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - open issue queue after residual-aware listening input guard merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware listening review pending boundary`
+- 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware completion audit`
 
 현재 범위가 아닌 것:
 
@@ -52,6 +53,10 @@
 - residual-aware MVP handoff freeze missing/checksum mismatch: `0 / 0`
 - residual-aware MVP handoff freeze raw artifact upload required: `false`
 - residual-aware MVP handoff freeze next boundary: `music_transformer_solo_yield_residual_aware_listening_review_pending`
+- residual-aware listening review pending candidate count: `8`
+- residual-aware listening review pending manual review required for quality claim: `true`
+- residual-aware listening review pending quality claim: `false`
+- residual-aware listening review pending next boundary: `music_transformer_solo_yield_residual_aware_completion_audit`
 - broader repaired sampling audit strict/grammar: `40 / 40` / `40 / 40`
 - broader repaired review package MIDI/WAV: `8 / 8`
 - broader repaired final handoff selected objective candidates: `4`

--- a/docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_PENDING_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_PENDING_2026-06-11.md
@@ -1,0 +1,27 @@
+# Music Transformer Solo Yield Residual-Aware Listening Review Pending
+
+## Summary
+
+- issue: `#1398`
+- candidate count: `8`
+- MIDI/WAV: `8` / `8`
+- quality proxy pass/fail: `6` / `2`
+- major labels: `low_tension_color=2`
+- watch labels: `dead_air_watch=3`
+- review input template: `outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_review/issue_1388_residual_aware_final_review_package/residual_aware_review_input_template.json`
+- review status: `pending`
+- pending candidate count: `8`
+- manual review required for quality claim: `true`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- listening review completed: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_residual_aware_completion_audit`
+
+## Not Proven
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `stable_jazz_solo_quality`
+- `production_ready_improviser`

--- a/scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py
+++ b/scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py
@@ -1,0 +1,365 @@
+"""Record the residual-aware listening review pending boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_listening_review_pending_v1"
+HANDOFF_FREEZE_SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_mvp_handoff_freeze_v1"
+REVIEW_INPUT_SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_review_input_v1"
+BOUNDARY = "music_transformer_solo_yield_residual_aware_listening_review_pending"
+NEXT_BOUNDARY = "music_transformer_solo_yield_residual_aware_completion_audit"
+
+
+class SoloYieldResidualAwareListeningReviewPendingError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _format_counts(value: dict[str, Any]) -> str:
+    if not value:
+        return "none"
+    return ", ".join(f"{key}={value[key]}" for key in sorted(value))
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldResidualAwareListeningReviewPendingError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [
+        key
+        for key in (
+            "human_audio_preference_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "musical_quality_claimed",
+            "artist_style_claimed",
+            "production_ready_claimed",
+        )
+        if bool(container.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldResidualAwareListeningReviewPendingError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_handoff_freeze(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != HANDOFF_FREEZE_SCHEMA_VERSION:
+        raise SoloYieldResidualAwareListeningReviewPendingError("handoff freeze schema mismatch")
+    aggregate = _dict(report.get("aggregate"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    artifact_paths = _dict(report.get("artifact_paths"))
+    if not bool(readiness.get("residual_aware_mvp_handoff_freeze_completed", False)):
+        raise SoloYieldResidualAwareListeningReviewPendingError("handoff freeze completion required")
+    if not bool(readiness.get("local_candidate_artifacts_verified", False)):
+        raise SoloYieldResidualAwareListeningReviewPendingError("local candidate artifacts verification required")
+    if not bool(readiness.get("review_input_template_available", False)):
+        raise SoloYieldResidualAwareListeningReviewPendingError("review input template availability required")
+    if bool(aggregate.get("raw_artifact_upload_required", True)):
+        raise SoloYieldResidualAwareListeningReviewPendingError("raw artifact upload should not be required")
+    if _int(aggregate.get("missing_file_count")) != 0:
+        raise SoloYieldResidualAwareListeningReviewPendingError("missing file count must be zero")
+    if _int(aggregate.get("checksum_mismatch_count")) != 0:
+        raise SoloYieldResidualAwareListeningReviewPendingError("checksum mismatch count must be zero")
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise SoloYieldResidualAwareListeningReviewPendingError("handoff freeze must route to pending boundary")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise SoloYieldResidualAwareListeningReviewPendingError("critical user input should not be required")
+    _require_no_quality_claim(readiness, label="handoff freeze readiness")
+    template_path = Path(str(artifact_paths.get("review_input_template_json") or ""))
+    if not template_path.exists() or not template_path.is_file():
+        raise SoloYieldResidualAwareListeningReviewPendingError(
+            f"review input template missing: {template_path}"
+        )
+    return {
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "midi_count": _int(aggregate.get("midi_count")),
+        "wav_count": _int(aggregate.get("wav_count")),
+        "quality_proxy_pass_count": _int(aggregate.get("quality_proxy_pass_count")),
+        "quality_proxy_fail_count": _int(aggregate.get("quality_proxy_fail_count")),
+        "major_label_counts": _dict(aggregate.get("major_label_counts")),
+        "watch_label_counts": _dict(aggregate.get("watch_label_counts")),
+        "review_input_template_path": str(template_path),
+        "validated_listening_input_present": bool(
+            readiness.get("validated_listening_input_present", True)
+        ),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "listening_review_completed": bool(readiness.get("listening_review_completed", True)),
+    }
+
+
+def validate_review_input_template(path: Path, *, expected_candidate_count: int) -> dict[str, Any]:
+    report = read_json(path)
+    if str(report.get("schema_version") or "") != REVIEW_INPUT_SCHEMA_VERSION:
+        raise SoloYieldResidualAwareListeningReviewPendingError("review input schema mismatch")
+    candidates = _list(report.get("candidates"))
+    if len(candidates) != expected_candidate_count:
+        raise SoloYieldResidualAwareListeningReviewPendingError("review input candidate count mismatch")
+    if str(report.get("review_status") or "") != "pending":
+        raise SoloYieldResidualAwareListeningReviewPendingError("review status must remain pending")
+    if str(report.get("overall_decision") or "") != "pending":
+        raise SoloYieldResidualAwareListeningReviewPendingError("overall decision must remain pending")
+    filled = [
+        row
+        for row in candidates
+        if str(_dict(row).get("decision") or "") != "pending"
+        or _dict(row).get("usable_as_jazz_solo_phrase") is not None
+        or _dict(row).get("primary_failure") is not None
+    ]
+    if filled:
+        raise SoloYieldResidualAwareListeningReviewPendingError("review input should not be filled")
+    return {
+        "schema_version": str(report.get("schema_version")),
+        "review_status": str(report.get("review_status")),
+        "overall_decision": str(report.get("overall_decision")),
+        "candidate_count": len(candidates),
+        "pending_candidate_count": len(candidates),
+    }
+
+
+def build_pending_report(
+    *,
+    handoff_freeze_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    handoff = validate_handoff_freeze(handoff_freeze_report)
+    review_input = validate_review_input_template(
+        Path(str(handoff["review_input_template_path"])),
+        expected_candidate_count=int(handoff["candidate_count"]),
+    )
+    pending_input = not bool(handoff["validated_listening_input_present"])
+    preference_blocked = not bool(handoff["preference_fill_allowed"])
+    listening_pending = not bool(handoff["listening_review_completed"])
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "source_reports": {
+            "handoff_freeze_report": handoff_freeze_report.get("output_dir"),
+        },
+        "aggregate": {
+            "candidate_count": handoff["candidate_count"],
+            "midi_count": handoff["midi_count"],
+            "wav_count": handoff["wav_count"],
+            "quality_proxy_pass_count": handoff["quality_proxy_pass_count"],
+            "quality_proxy_fail_count": handoff["quality_proxy_fail_count"],
+            "major_label_counts": handoff["major_label_counts"],
+            "watch_label_counts": handoff["watch_label_counts"],
+            "pending_candidate_count": review_input["pending_candidate_count"],
+        },
+        "review_input": {
+            "path": handoff["review_input_template_path"],
+            "schema_version": review_input["schema_version"],
+            "review_status": review_input["review_status"],
+            "overall_decision": review_input["overall_decision"],
+            "candidate_count": review_input["candidate_count"],
+            "pending_candidate_count": review_input["pending_candidate_count"],
+        },
+        "readiness": {
+            "residual_aware_listening_review_pending_recorded": True,
+            "local_mvp_handoff_ready": True,
+            "review_input_template_pending": True,
+            "manual_review_required_for_quality_claim": True,
+            "validated_listening_input_present": pending_input is False,
+            "preference_fill_allowed": preference_blocked is False,
+            "listening_review_completed": listening_pending is False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+            "reason": "listening review input remains pending; technical completion audit can proceed without quality claim",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "stable_jazz_solo_quality",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "residual_aware_listening_review_pending.json", report)
+    write_json(
+        output_dir / "residual_aware_listening_review_pending_summary.json",
+        validate_pending_report(report),
+    )
+    write_text(output_dir / "residual_aware_listening_review_pending.md", markdown_report(report))
+    return report
+
+
+def validate_pending_report(
+    report: dict[str, Any],
+    *,
+    expected_next_boundary: str | None = None,
+    require_pending_review: bool = False,
+    require_no_quality_claim: bool = False,
+) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldResidualAwareListeningReviewPendingError("pending report schema mismatch")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    if not bool(readiness.get("residual_aware_listening_review_pending_recorded", False)):
+        raise SoloYieldResidualAwareListeningReviewPendingError("pending boundary record required")
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise SoloYieldResidualAwareListeningReviewPendingError("unexpected next boundary")
+    if require_pending_review:
+        if not bool(readiness.get("review_input_template_pending", False)):
+            raise SoloYieldResidualAwareListeningReviewPendingError("review input template must be pending")
+        if not bool(readiness.get("manual_review_required_for_quality_claim", False)):
+            raise SoloYieldResidualAwareListeningReviewPendingError("manual review requirement should be recorded")
+        if bool(readiness.get("validated_listening_input_present", True)):
+            raise SoloYieldResidualAwareListeningReviewPendingError("validated listening input should remain pending")
+        if bool(readiness.get("preference_fill_allowed", True)):
+            raise SoloYieldResidualAwareListeningReviewPendingError("preference fill should remain blocked")
+        if bool(readiness.get("listening_review_completed", True)):
+            raise SoloYieldResidualAwareListeningReviewPendingError("listening review should remain pending")
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="pending readiness")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise SoloYieldResidualAwareListeningReviewPendingError("critical user input should not be required")
+    return {
+        "schema_version": str(report.get("schema_version")),
+        "local_mvp_handoff_ready": bool(readiness.get("local_mvp_handoff_ready", False)),
+        "review_input_template_pending": bool(readiness.get("review_input_template_pending", False)),
+        "manual_review_required_for_quality_claim": bool(
+            readiness.get("manual_review_required_for_quality_claim", False)
+        ),
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "midi_count": _int(aggregate.get("midi_count")),
+        "wav_count": _int(aggregate.get("wav_count")),
+        "pending_candidate_count": _int(aggregate.get("pending_candidate_count")),
+        "validated_listening_input_present": bool(
+            readiness.get("validated_listening_input_present", True)
+        ),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "listening_review_completed": bool(readiness.get("listening_review_completed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    review_input = report["review_input"]
+    lines = [
+        "# Music Transformer Solo Yield Residual-Aware Listening Review Pending",
+        "",
+        "## Summary",
+        "",
+        f"- issue: `#{report['issue_number']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- MIDI/WAV: `{aggregate['midi_count']}` / `{aggregate['wav_count']}`",
+        (
+            "- quality proxy pass/fail: "
+            f"`{aggregate['quality_proxy_pass_count']}` / `{aggregate['quality_proxy_fail_count']}`"
+        ),
+        f"- major labels: `{_format_counts(aggregate['major_label_counts'])}`",
+        f"- watch labels: `{_format_counts(aggregate['watch_label_counts'])}`",
+        f"- review input template: `{review_input['path']}`",
+        f"- review status: `{review_input['review_status']}`",
+        f"- pending candidate count: `{aggregate['pending_candidate_count']}`",
+        (
+            "- manual review required for quality claim: "
+            f"`{_bool_token(readiness['manual_review_required_for_quality_claim'])}`"
+        ),
+        f"- validated listening input present: `{_bool_token(readiness['validated_listening_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(readiness['preference_fill_allowed'])}`",
+        f"- listening review completed: `{_bool_token(readiness['listening_review_completed'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Record residual-aware listening review pending boundary")
+    parser.add_argument("--handoff_freeze_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_listening_review_pending",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=0)
+    parser.add_argument("--expected_next_boundary", type=str, default=NEXT_BOUNDARY)
+    parser.add_argument("--require_pending_review", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_pending_report(
+        handoff_freeze_report=read_json(Path(args.handoff_freeze_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_pending_report(
+        report,
+        expected_next_boundary=str(args.expected_next_boundary),
+        require_pending_review=bool(args.require_pending_review),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_residual_aware_listening_review_pending.py
+++ b/tests/test_music_transformer_solo_yield_residual_aware_listening_review_pending.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.mark_music_transformer_solo_yield_residual_aware_listening_review_pending import (
+    NEXT_BOUNDARY,
+    SoloYieldResidualAwareListeningReviewPendingError,
+    build_pending_report,
+    validate_pending_report,
+)
+
+
+def review_input_template(path: Path, *, filled: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "schema_version": "music_transformer_solo_yield_residual_aware_review_input_v1",
+        "review_status": "pending",
+        "overall_decision": "pending",
+        "candidates": [
+            {
+                "review_index": 1,
+                "decision": "keep" if filled else "pending",
+                "usable_as_jazz_solo_phrase": True if filled else None,
+                "primary_failure": None,
+            },
+            {
+                "review_index": 2,
+                "decision": "pending",
+                "usable_as_jazz_solo_phrase": None,
+                "primary_failure": None,
+            },
+        ],
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def handoff_freeze(root: Path, *, quality_claim: bool = False, filled_input: bool = False) -> dict:
+    template_path = root / "review_input_template.json"
+    review_input_template(template_path, filled=filled_input)
+    return {
+        "schema_version": "music_transformer_solo_yield_residual_aware_mvp_handoff_freeze_v1",
+        "output_dir": "outputs/handoff",
+        "artifact_paths": {
+            "review_input_template_json": str(template_path),
+        },
+        "aggregate": {
+            "candidate_count": 2,
+            "midi_count": 2,
+            "wav_count": 2,
+            "quality_proxy_pass_count": 1,
+            "quality_proxy_fail_count": 1,
+            "major_label_counts": {"low_tension_color": 1},
+            "watch_label_counts": {"dead_air_watch": 1},
+            "missing_file_count": 0,
+            "checksum_mismatch_count": 0,
+            "raw_artifact_upload_required": False,
+        },
+        "readiness": {
+            "residual_aware_mvp_handoff_freeze_completed": True,
+            "local_candidate_artifacts_verified": True,
+            "review_input_template_available": True,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "listening_review_completed": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "music_transformer_solo_yield_residual_aware_listening_review_pending",
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldResidualAwareListeningReviewPendingTest(unittest.TestCase):
+    def test_records_pending_boundary_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            root = Path(raw_temp)
+            report = build_pending_report(
+                handoff_freeze_report=handoff_freeze(root),
+                output_dir=root / "pending",
+                issue_number=1398,
+            )
+        summary = validate_pending_report(
+            report,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_pending_review=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["local_mvp_handoff_ready"])
+        self.assertTrue(summary["review_input_template_pending"])
+        self.assertTrue(summary["manual_review_required_for_quality_claim"])
+        self.assertEqual(summary["candidate_count"], 2)
+        self.assertEqual(summary["pending_candidate_count"], 2)
+        self.assertFalse(summary["validated_listening_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertFalse(summary["listening_review_completed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_filled_review_input_template(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            root = Path(raw_temp)
+            with self.assertRaises(SoloYieldResidualAwareListeningReviewPendingError):
+                build_pending_report(
+                    handoff_freeze_report=handoff_freeze(root, filled_input=True),
+                    output_dir=root / "pending",
+                    issue_number=1398,
+                )
+
+    def test_rejects_quality_claim_in_handoff_freeze(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            root = Path(raw_temp)
+            with self.assertRaises(SoloYieldResidualAwareListeningReviewPendingError):
+                build_pending_report(
+                    handoff_freeze_report=handoff_freeze(root, quality_claim=True),
+                    output_dir=root / "pending",
+                    issue_number=1398,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- residual-aware listening review pending boundary 스크립트 추가
- #1396 handoff freeze 이후 review input template pending 상태 검증
- quality claim 차단 조건 문서화
- README / CURRENT_STATUS_AND_PLAN / CORE_PLAN 갱신

## Context
- #1396 handoff freeze: local artifacts verified true, MIDI/WAV 8 / 8, checksum mismatch 0
- review input template: candidate 8, status pending
- validated listening input false, preference fill false, listening review completed false
- musical quality claim false

## Scope
- scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py
- tests/test_music_transformer_solo_yield_residual_aware_listening_review_pending.py
- residual-aware listening review pending markdown 기록
- README/current status/core plan 최신 boundary 반영

## Validation
- public artifact tool-name scan: no matches
- git diff --cached --check
- .venv/bin/python -m unittest tests.test_music_transformer_solo_yield_residual_aware_listening_review_pending
- .venv/bin/python -m py_compile scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py tests/test_music_transformer_solo_yield_residual_aware_listening_review_pending.py
- .venv/bin/python scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py --run_id issue_1398_residual_aware_listening_review_pending --issue_number 1398 --handoff_freeze_report outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_mvp_handoff_freeze/issue_1396_residual_aware_mvp_handoff_freeze/residual_aware_mvp_handoff_freeze.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_PENDING_2026-06-11.md --expected_next_boundary music_transformer_solo_yield_residual_aware_completion_audit --require_pending_review --require_no_quality_claim
- bash scripts/agent_harness.sh quick

## Risk
- listening review input을 임의로 채우지 않음
- preference fill false 유지
- musical quality claim false 유지

Closes #1398