### PR TITLE
Stage B MIDI-to-solo residual-aware listening review input wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - residual-aware listening review pending: pending candidate `8`, quality claim `false`
 - residual-aware completion audit: technical MVP complete `true`, local review ready `true`
 - residual-aware final status sync: synced `true`, next `listening_review_input_wait`
+- residual-aware listening review input wait: quality claim blocked `true`
 
 ## 최신 산출물
 
@@ -58,6 +59,7 @@
 - listening review pending doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_PENDING_2026-06-11.md`
 - completion audit doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_COMPLETION_AUDIT_2026-06-11.md`
 - final status sync doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_STATUS_SYNC_2026-06-11.md`
+- listening review input wait doc: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_INPUT_WAIT_2026-06-11.md`
 
 ## 재현 명령
 
@@ -121,6 +123,15 @@
   --require_no_quality_claim
 ```
 
+```bash
+.venv/bin/python scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py \
+  --run_id issue_1404_residual_aware_listening_review_input_wait \
+  --final_status_sync outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_status_sync/issue_1402_residual_aware_final_status_sync/residual_aware_final_status_sync.json \
+  --expected_next_boundary music_transformer_solo_yield_residual_aware_user_listening_review_fill \
+  --require_wait_recorded \
+  --require_no_quality_claim
+```
+
 ## 아닌 것
 
 - 완성형 jazz solo quality claim 아님
@@ -138,6 +149,7 @@
 - `scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_pending.py`
 - `scripts/audit_music_transformer_solo_yield_residual_aware_completion.py`
 - `scripts/sync_music_transformer_solo_yield_residual_aware_final_status.py`
+- `scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py`
 - `scripts/build_music_transformer_solo_yield_objective_quality_rubric_baseline.py`
 - `scripts/decide_music_transformer_solo_yield_residual_tension_target.py`
 - `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_REVIEW_PACKAGE_2026-06-11.md`
@@ -146,3 +158,4 @@
 - `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_PENDING_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_COMPLETION_AUDIT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_FINAL_STATUS_SYNC_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_INPUT_WAIT_2026-06-11.md`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -13711,6 +13711,46 @@ Issue #1402는 #1400 completion audit 결과를 README와 CURRENT_STATUS_AND_PLA
 
 - `Stage B MIDI-to-solo residual-aware listening review input wait`
 
+## 9.251 Stage B MIDI-to-solo residual-aware listening review input wait
+
+Issue #1404는 #1402 final status sync 이후 user listening review 입력 대기 상태를 고정한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_INPUT_WAIT_2026-06-11.md`
+- output: `outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_listening_review_input_wait/issue_1404_residual_aware_listening_review_input_wait/`
+- boundary: `music_transformer_solo_yield_residual_aware_listening_review_input_wait`
+- source final status schema: `music_transformer_solo_yield_residual_aware_final_status_sync_v1`
+- technical MVP complete: `true`
+- final status synced: `true`
+- local review ready: `true`
+- candidate count: `8`
+- MIDI/WAV: `8 / 8`
+- pending candidate count: `8`
+- quality proxy pass/fail: `6 / 2`
+- residual major label: `low_tension_color=2`
+- residual watch label: `dead_air_watch=3`
+- user listening input required for quality claim: `true`
+- automated quality claim blocked: `true`
+- MIDI-to-solo musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_residual_aware_user_listening_review_fill`
+
+판단:
+
+- technical MVP는 완료됐지만, quality claim은 user listening review 입력 전까지 차단.
+- user listening input이 들어오면 review fill 경계로 진행 가능.
+- 현재 자동화 범위에서 preference fill 임의 생성 없음.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_music_transformer_solo_yield_residual_aware_listening_review_input_wait`
+- `.venv/bin/python -m py_compile scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py tests/test_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py`
+- `.venv/bin/python scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py --run_id issue_1404_residual_aware_listening_review_input_wait --issue_number 1404 --final_status_sync outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_status_sync/issue_1402_residual_aware_final_status_sync/residual_aware_final_status_sync.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_INPUT_WAIT_2026-06-11.md --expected_next_boundary music_transformer_solo_yield_residual_aware_user_listening_review_fill --require_wait_recorded --require_no_quality_claim`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo residual-aware user listening review fill`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -19,9 +19,10 @@
 - latest residual-aware MVP handoff freeze: Issue #1396, Stage B MIDI-to-solo residual-aware MVP handoff freeze
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
-- current issue: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
+- latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
+- current issue: Issue #1404, Stage B MIDI-to-solo residual-aware listening review input wait
 - open issue queue after residual-aware listening input guard merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware listening review input wait`
+- 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
 현재 범위가 아닌 것:
 
@@ -67,6 +68,10 @@
 - residual-aware final status sync MIDI/WAV: `8 / 8`
 - residual-aware final status sync quality claim: `false`
 - residual-aware final status sync next boundary: `music_transformer_solo_yield_residual_aware_listening_review_input_wait`
+- residual-aware listening review input wait user input required for quality claim: `true`
+- residual-aware listening review input wait automated quality claim blocked: `true`
+- residual-aware listening review input wait quality claim: `false`
+- residual-aware listening review input wait next boundary: `music_transformer_solo_yield_residual_aware_user_listening_review_fill`
 - broader repaired sampling audit strict/grammar: `40 / 40` / `40 / 40`
 - broader repaired review package MIDI/WAV: `8 / 8`
 - broader repaired final handoff selected objective candidates: `4`

--- a/docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_INPUT_WAIT_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_INPUT_WAIT_2026-06-11.md
@@ -1,0 +1,26 @@
+# Music Transformer Solo Yield Residual-Aware Listening Review Input Wait
+
+## Summary
+
+- issue: `#1404`
+- technical MVP complete: `true`
+- final status synced: `true`
+- local review ready: `true`
+- candidate count: `8`
+- MIDI/WAV: `8` / `8`
+- pending candidate count: `8`
+- quality proxy pass/fail: `6` / `2`
+- major labels: `low_tension_color=2`
+- watch labels: `dead_air_watch=3`
+- user listening input required for quality claim: `true`
+- automated quality claim blocked: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_residual_aware_user_listening_review_fill`
+
+## Not Proven
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `stable_jazz_solo_quality`
+- `production_ready_improviser`

--- a/scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py
+++ b/scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py
@@ -1,0 +1,311 @@
+"""Record residual-aware listening review input wait state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_listening_review_input_wait_v1"
+FINAL_STATUS_SCHEMA_VERSION = "music_transformer_solo_yield_residual_aware_final_status_sync_v1"
+BOUNDARY = "music_transformer_solo_yield_residual_aware_listening_review_input_wait"
+NEXT_BOUNDARY = "music_transformer_solo_yield_residual_aware_user_listening_review_fill"
+
+
+class SoloYieldResidualAwareListeningReviewInputWaitError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _format_counts(value: dict[str, Any]) -> str:
+    if not value:
+        return "none"
+    return ", ".join(f"{key}={value[key]}" for key in sorted(value))
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldResidualAwareListeningReviewInputWaitError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [
+        key
+        for key in (
+            "human_audio_preference_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "musical_quality_claimed",
+            "artist_style_claimed",
+            "production_ready_claimed",
+        )
+        if bool(container.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldResidualAwareListeningReviewInputWaitError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_final_status_sync(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != FINAL_STATUS_SCHEMA_VERSION:
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("final status sync schema mismatch")
+    aggregate = _dict(report.get("aggregate"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if not bool(readiness.get("residual_aware_final_status_sync_completed", False)):
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("final status sync completion required")
+    if not bool(readiness.get("residual_aware_final_status_synced", False)):
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("final status synced required")
+    if not bool(readiness.get("technical_mvp_complete", False)):
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("technical MVP completion required")
+    if not bool(readiness.get("local_review_ready", False)):
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("local review readiness required")
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("final status must route to input wait")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("critical user input should not be required")
+    if _int(aggregate.get("candidate_count")) <= 0:
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("candidate count required")
+    if _int(aggregate.get("pending_candidate_count")) != _int(aggregate.get("candidate_count")):
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("pending candidate count mismatch")
+    _require_no_quality_claim(readiness, label="final status readiness")
+    return {
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "midi_count": _int(aggregate.get("midi_count")),
+        "wav_count": _int(aggregate.get("wav_count")),
+        "pending_candidate_count": _int(aggregate.get("pending_candidate_count")),
+        "quality_proxy_pass_count": _int(aggregate.get("quality_proxy_pass_count")),
+        "quality_proxy_fail_count": _int(aggregate.get("quality_proxy_fail_count")),
+        "major_label_counts": _dict(aggregate.get("major_label_counts")),
+        "watch_label_counts": _dict(aggregate.get("watch_label_counts")),
+    }
+
+
+def build_input_wait_report(
+    *,
+    final_status_sync_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary = validate_final_status_sync(final_status_sync_report)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "source_reports": {
+            "final_status_sync": final_status_sync_report.get("output_dir"),
+        },
+        "aggregate": {
+            "candidate_count": summary["candidate_count"],
+            "midi_count": summary["midi_count"],
+            "wav_count": summary["wav_count"],
+            "pending_candidate_count": summary["pending_candidate_count"],
+            "quality_proxy_pass_count": summary["quality_proxy_pass_count"],
+            "quality_proxy_fail_count": summary["quality_proxy_fail_count"],
+            "major_label_counts": summary["major_label_counts"],
+            "watch_label_counts": summary["watch_label_counts"],
+        },
+        "readiness": {
+            "residual_aware_listening_review_input_wait_recorded": True,
+            "technical_mvp_complete": True,
+            "final_status_synced": True,
+            "local_review_ready": True,
+            "user_listening_input_required_for_quality_claim": True,
+            "automated_quality_claim_blocked": True,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "listening_review_completed": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+            "reason": "technical MVP complete; wait for user listening input before review fill or quality claim",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "stable_jazz_solo_quality",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "residual_aware_listening_review_input_wait.json", report)
+    write_json(
+        output_dir / "residual_aware_listening_review_input_wait_summary.json",
+        validate_input_wait_report(report),
+    )
+    write_text(output_dir / "residual_aware_listening_review_input_wait.md", markdown_report(report))
+    return report
+
+
+def validate_input_wait_report(
+    report: dict[str, Any],
+    *,
+    expected_next_boundary: str | None = None,
+    require_wait_recorded: bool = False,
+    require_no_quality_claim: bool = False,
+) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("input wait schema mismatch")
+    aggregate = _dict(report.get("aggregate"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if not bool(readiness.get("residual_aware_listening_review_input_wait_recorded", False)):
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("input wait record required")
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("unexpected next boundary")
+    if require_wait_recorded:
+        if not bool(readiness.get("technical_mvp_complete", False)):
+            raise SoloYieldResidualAwareListeningReviewInputWaitError("technical MVP completion required")
+        if not bool(readiness.get("user_listening_input_required_for_quality_claim", False)):
+            raise SoloYieldResidualAwareListeningReviewInputWaitError("user listening input requirement required")
+        if not bool(readiness.get("automated_quality_claim_blocked", False)):
+            raise SoloYieldResidualAwareListeningReviewInputWaitError("automated quality claim block required")
+        if bool(readiness.get("validated_listening_input_present", True)):
+            raise SoloYieldResidualAwareListeningReviewInputWaitError("validated listening input should remain false")
+        if bool(readiness.get("preference_fill_allowed", True)):
+            raise SoloYieldResidualAwareListeningReviewInputWaitError("preference fill should remain false")
+        if bool(readiness.get("listening_review_completed", True)):
+            raise SoloYieldResidualAwareListeningReviewInputWaitError("listening review should remain false")
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="input wait readiness")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise SoloYieldResidualAwareListeningReviewInputWaitError("critical user input should not be required")
+    return {
+        "schema_version": str(report.get("schema_version")),
+        "technical_mvp_complete": bool(readiness.get("technical_mvp_complete", False)),
+        "final_status_synced": bool(readiness.get("final_status_synced", False)),
+        "local_review_ready": bool(readiness.get("local_review_ready", False)),
+        "user_listening_input_required_for_quality_claim": bool(
+            readiness.get("user_listening_input_required_for_quality_claim", False)
+        ),
+        "automated_quality_claim_blocked": bool(
+            readiness.get("automated_quality_claim_blocked", False)
+        ),
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "midi_count": _int(aggregate.get("midi_count")),
+        "wav_count": _int(aggregate.get("wav_count")),
+        "pending_candidate_count": _int(aggregate.get("pending_candidate_count")),
+        "validated_listening_input_present": bool(
+            readiness.get("validated_listening_input_present", True)
+        ),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "listening_review_completed": bool(readiness.get("listening_review_completed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Music Transformer Solo Yield Residual-Aware Listening Review Input Wait",
+        "",
+        "## Summary",
+        "",
+        f"- issue: `#{report['issue_number']}`",
+        f"- technical MVP complete: `{_bool_token(readiness['technical_mvp_complete'])}`",
+        f"- final status synced: `{_bool_token(readiness['final_status_synced'])}`",
+        f"- local review ready: `{_bool_token(readiness['local_review_ready'])}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- MIDI/WAV: `{aggregate['midi_count']}` / `{aggregate['wav_count']}`",
+        f"- pending candidate count: `{aggregate['pending_candidate_count']}`",
+        (
+            "- quality proxy pass/fail: "
+            f"`{aggregate['quality_proxy_pass_count']}` / `{aggregate['quality_proxy_fail_count']}`"
+        ),
+        f"- major labels: `{_format_counts(aggregate['major_label_counts'])}`",
+        f"- watch labels: `{_format_counts(aggregate['watch_label_counts'])}`",
+        (
+            "- user listening input required for quality claim: "
+            f"`{_bool_token(readiness['user_listening_input_required_for_quality_claim'])}`"
+        ),
+        f"- automated quality claim blocked: `{_bool_token(readiness['automated_quality_claim_blocked'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Record residual-aware listening review input wait")
+    parser.add_argument("--final_status_sync", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_listening_review_input_wait",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=0)
+    parser.add_argument("--expected_next_boundary", type=str, default=NEXT_BOUNDARY)
+    parser.add_argument("--require_wait_recorded", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_input_wait_report(
+        final_status_sync_report=read_json(Path(args.final_status_sync)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_input_wait_report(
+        report,
+        expected_next_boundary=str(args.expected_next_boundary),
+        require_wait_recorded=bool(args.require_wait_recorded),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py
+++ b/tests/test_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait import (
+    NEXT_BOUNDARY,
+    SoloYieldResidualAwareListeningReviewInputWaitError,
+    build_input_wait_report,
+    validate_input_wait_report,
+)
+
+
+def final_status_sync(*, quality_claim: bool = False) -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_residual_aware_final_status_sync_v1",
+        "output_dir": "outputs/final_status",
+        "aggregate": {
+            "candidate_count": 8,
+            "midi_count": 8,
+            "wav_count": 8,
+            "pending_candidate_count": 8,
+            "quality_proxy_pass_count": 6,
+            "quality_proxy_fail_count": 2,
+            "major_label_counts": {"low_tension_color": 2},
+            "watch_label_counts": {"dead_air_watch": 3},
+        },
+        "readiness": {
+            "residual_aware_final_status_sync_completed": True,
+            "residual_aware_final_status_synced": True,
+            "technical_mvp_complete": True,
+            "local_review_ready": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "music_transformer_solo_yield_residual_aware_listening_review_input_wait",
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldResidualAwareListeningReviewInputWaitTest(unittest.TestCase):
+    def test_records_wait_state_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            report = build_input_wait_report(
+                final_status_sync_report=final_status_sync(),
+                output_dir=Path(raw_temp) / "wait",
+                issue_number=1404,
+            )
+        summary = validate_input_wait_report(
+            report,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_wait_recorded=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["technical_mvp_complete"])
+        self.assertTrue(summary["final_status_synced"])
+        self.assertTrue(summary["local_review_ready"])
+        self.assertTrue(summary["user_listening_input_required_for_quality_claim"])
+        self.assertTrue(summary["automated_quality_claim_blocked"])
+        self.assertEqual(summary["candidate_count"], 8)
+        self.assertEqual(summary["pending_candidate_count"], 8)
+        self.assertFalse(summary["validated_listening_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_quality_claim_in_final_status(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            with self.assertRaises(SoloYieldResidualAwareListeningReviewInputWaitError):
+                build_input_wait_report(
+                    final_status_sync_report=final_status_sync(quality_claim=True),
+                    output_dir=Path(raw_temp) / "wait",
+                    issue_number=1404,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- residual-aware listening review input wait 스크립트 추가
- #1402 final status sync 이후 wait 상태 기록
- technical MVP complete와 quality claim 차단 상태 분리
- README / CURRENT_STATUS_AND_PLAN / CORE_PLAN 갱신

## Context
- #1402 final status sync: technical MVP complete true, final status synced true
- candidate 8, MIDI/WAV 8 / 8, pending candidate 8
- user listening input required for quality claim true
- automated quality claim blocked true
- musical quality claim false

## Scope
- scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py
- tests/test_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py
- residual-aware listening review input wait markdown 기록
- README/current status/core plan 최신 wait boundary 반영

## Validation
- public artifact tool-name scan: no matches
- git diff --cached --check
- .venv/bin/python -m unittest tests.test_music_transformer_solo_yield_residual_aware_listening_review_input_wait
- .venv/bin/python -m py_compile scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py tests/test_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py
- .venv/bin/python scripts/mark_music_transformer_solo_yield_residual_aware_listening_review_input_wait.py --run_id issue_1404_residual_aware_listening_review_input_wait --issue_number 1404 --final_status_sync outputs/music_transformer_finetune_mvp/solo_yield_residual_aware_final_status_sync/issue_1402_residual_aware_final_status_sync/residual_aware_final_status_sync.json --doc_path docs/STAGE_B_MIDI_TO_SOLO_RESIDUAL_AWARE_LISTENING_REVIEW_INPUT_WAIT_2026-06-11.md --expected_next_boundary music_transformer_solo_yield_residual_aware_user_listening_review_fill --require_wait_recorded --require_no_quality_claim
- bash scripts/agent_harness.sh quick

## Risk
- user listening input을 임의 생성하지 않음
- preference fill false 유지
- musical quality claim false 유지

Closes #1404