### PR TITLE
Stage B bebop language residual adjacent repeat repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 - 생성 방식: Music Transformer 계열 symbolic checkpoint + constrained decoding
 - 출력 단위: 2-8마디 solo-line MIDI 후보
-- 최신 대표 review package: strict-listen top4 adjacent-repeat-final-repair, MIDI `4`, WAV `4`
+- 최신 대표 review package: strict-listen top4 residual-adjacent-search-repair, MIDI `4`, WAV `4`
 - 최신 objective gate: max gate penalty `0.0000`
-- 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0476`, adjacent repeat `0.0040`, enclosure proxy `0.3438`, bar pitch-class similarity `0.5774`
+- 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0516`, adjacent repeat `0.0000`, enclosure proxy `0.3516`, bar pitch-class similarity `0.5774`
 - 기준 best-of review package: MIDI `16`, WAV `16`
 - residual-aware objective rubric: pass/fail `6 / 2`
 - validated listening input: `false`
@@ -55,6 +55,7 @@
 - bebop language strict-listen top4 large-leap-repair package: source package `119`, pool `1711`, selection pool `16`, selected `4`, select-after-repair `true`, strong-beat chord-tone `1.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.1151 -> 0.0595`, enclosure proxy `0.3203`, two-note cycle `0.0000`, max gate penalty `0.0000`
 - bebop language strict-listen top4 bebop-selection-profile package: source package `125`, pool `1807`, selection pool `18`, selected `4`, select-after-repair `true`, selection profile `bebop_language`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.0476`, enclosure proxy `0.3516`, two-note cycle `0.0000`, interval trigram repeat `0.0123`, bar pitch-class similarity `0.5774`, max gate penalty `0.0000`
 - bebop language strict-listen top4 adjacent-repeat-final-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, select-after-repair `true`, selection profile `bebop_language`, adjacent repeat `0.0119 -> 0.0040`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.0476`, enclosure proxy `0.3438`, two-note cycle `0.0000`, interval trigram repeat `0.0123`, bar pitch-class similarity `0.5774`, max gate penalty `0.0000`
+- bebop language strict-listen top4 residual-adjacent-search-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, select-after-repair `true`, selection profile `bebop_language`, adjacent repeat `0.0040 -> 0.0000`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.0516`, enclosure proxy `0.3516`, two-note cycle `0.0000`, interval trigram repeat `0.0123`, bar pitch-class similarity `0.5774`, max gate penalty `0.0000`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -87,6 +88,8 @@
 - strict-listen top4 bebop-selection-profile note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_bebop_selection_profile_note_review/bebop_language_note_review.md`
 - strict-listen top4 adjacent-repeat-final-repair 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_adjacent_repeat_final_repair_probe/listen_first_by_progression/`
 - strict-listen top4 adjacent-repeat-final-repair note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_adjacent_repeat_final_repair_note_review/bebop_language_note_review.md`
+- strict-listen top4 residual-adjacent-search-repair 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe/listen_first_by_progression/`
+- strict-listen top4 residual-adjacent-search-repair note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_residual_adjacent_search_repair_note_review/bebop_language_note_review.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -109,7 +112,7 @@
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py \
-  --run_id manual_2026_06_13_bebop_language_best_of_top4_adjacent_repeat_final_repair_probe \
+  --run_id manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe \
   --package_globs 'manual_2026_06_13_bebop_language_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json' \
   --selected_count 4 \
   --max_per_case 1 \
@@ -142,8 +145,8 @@
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
-  --run_id manual_2026_06_13_bebop_language_top4_adjacent_repeat_final_repair_note_review \
-  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_adjacent_repeat_final_repair_probe/bebop_language_best_of_package.json \
+  --run_id manual_2026_06_13_bebop_language_top4_residual_adjacent_search_repair_note_review \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe/bebop_language_best_of_package.json \
   --max_notes 32
 ```
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1406, Stage B MIDI-to-solo bebop language listen-first quality iteration
+- current issue: Issue #1408, Stage B MIDI-to-solo bebop language residual adjacent repeat repair
 - open issue queue after residual-aware listening input guard merge: `0`
 - 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
@@ -42,22 +42,22 @@
 
 2026-06-13 best-of strict consonance 기준:
 
-- latest local package: `manual_2026_06_13_bebop_language_best_of_top4_adjacent_repeat_final_repair_probe`
+- latest local package: `manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe`
 - source package count: `125`
 - candidate pool / selection pool / selected: `1807 / 18 / 4`
 - selection profile: `bebop_language`
 - strong-beat chord-tone: `1.0000`
 - offbeat non-chord / resolution / unresolved: `0.3906 / 1.0000 / 0.0000`
-- large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0476 / 0.0040 / 0.3438 / 0.5774`
+- large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0516 / 0.0000 / 0.3516 / 0.5774`
 - altered offbeat / two-note cycle / interval trigram repeat: `0.1250 / 0.0000 / 0.0123`
 - max gate penalty: `0.0000`
-- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_adjacent_repeat_final_repair_probe/listen_first_by_progression/`
-- note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_adjacent_repeat_final_repair_note_review/bebop_language_note_review.md`
+- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe/listen_first_by_progression/`
+- note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_residual_adjacent_search_repair_note_review/bebop_language_note_review.md`
 - quality claim: `false`
 - model direct claim: `false`
-- previous top4 selection-profile package: `manual_2026_06_13_bebop_language_best_of_top4_bebop_selection_profile_probe`
-- adjacent-repeat final repair delta: `0.0119 -> 0.0040`
-- preserved metrics after adjacent-repeat repair: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, large leap `0.0476`, bar pitch-class similarity `0.5774`
+- previous top4 adjacent-repeat-final package: `manual_2026_06_13_bebop_language_best_of_top4_adjacent_repeat_final_repair_probe`
+- residual adjacent-search repair delta: adjacent repeat `0.0040 -> 0.0000`, large leap `0.0476 -> 0.0516`, enclosure proxy `0.3438 -> 0.3516`
+- preserved metrics after residual adjacent-search repair: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, bar pitch-class similarity `0.5774`
 
 2026-06-13 previous best-of strict consonance 기준:
 

--- a/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
+++ b/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
@@ -729,8 +729,8 @@ def adjacent_repeat_replacement_pitches(
     reference = int(next_note.pitch) if next_note is not None else int(previous.pitch) + 3
     candidates = pitches_for_pcs(
         allowed_pcs,
-        low=max(56, int(previous.pitch) - 5),
-        high=min(86, int(previous.pitch) + 5),
+        low=max(56, int(previous.pitch) - 8),
+        high=min(86, int(previous.pitch) + 8),
     )
     return sorted(
         [
@@ -738,7 +738,7 @@ def adjacent_repeat_replacement_pitches(
             for pitch in candidates
             if int(pitch) != int(note.pitch)
             and (next_note is None or int(pitch) != int(next_note.pitch))
-            and abs(int(pitch) - int(previous.pitch)) <= 5
+            and abs(int(pitch) - int(previous.pitch)) <= 8
             and (next_note is None or abs(int(next_note.pitch) - int(pitch)) <= 7)
         ],
         key=lambda pitch: (abs(int(pitch) - reference), abs(int(pitch) - int(note.pitch)), int(pitch)),
@@ -802,7 +802,7 @@ def repair_adjacent_repeats(
                     float(current_metrics["max_bar_pitch_class_jaccard"]) + 0.05,
                 ):
                     continue
-                if float(metrics["large_leap_ratio"]) > max(0.0625, float(current_metrics["large_leap_ratio"])):
+                if float(metrics["large_leap_ratio"]) > max(0.065, float(current_metrics["large_leap_ratio"])):
                     continue
                 score = candidate_score(
                     metrics,


### PR DESCRIPTION
## Summary
- strict-listen top4 residual adjacent repeat repair 범위 확장
- README/CURRENT_STATUS 최신 대표 패키지 갱신
- residual repair note review 경로 기록

## Context
- #1407 이후 representative top4 package adjacent repeat: `0.0040`
- residual 반복 위치: `rhythm_turnaround` 후보 동일 pitch 반복 1건
- 이전 adjacent repair 탐색 범위: 이전 pitch 기준 `±5`
- 관측된 safe replacement 후보: 이전 pitch 기준 `+6` 영역 필요

## Scope
- adjacent repeat replacement search: `±5 -> ±8`
- large leap guard: residual replacement 수용 범위 `0.065` 적용
- latest package: `manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe`
- latest note review: `manual_2026_06_13_bebop_language_top4_residual_adjacent_search_repair_note_review`

## Result
- adjacent repeat: `0.0040 -> 0.0000`
- large leap: `0.0476 -> 0.0516`
- enclosure proxy: `0.3438 -> 0.3516`
- max gate penalty: `0.0000`
- offbeat resolution / unresolved: `1.0000 / 0.0000`
- quality claim: `false`

## Validation
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh demo`

## Risk
- objective proxy improvement only
- listening preference and musical quality claim excluded
- large leap ratio 소폭 증가: `0.0476 -> 0.0516`, 기존 large-leap repair representative `0.0595` 이내

Closes #1408