### PR TITLE
Stage B bebop language rhythm articulation repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 
 - 생성 방식: Music Transformer 계열 symbolic checkpoint + constrained decoding
 - 출력 단위: 2-8마디 solo-line MIDI 후보
-- 최신 대표 review package: strict-listen top4 residual-adjacent-search-repair, MIDI `4`, WAV `4`
+- 최신 대표 review package: strict-listen top4 rhythm-articulation-repair, MIDI `4`, WAV `4`
 - 최신 objective gate: max gate penalty `0.0000`
 - 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0516`, adjacent repeat `0.0000`, enclosure proxy `0.3516`, bar pitch-class similarity `0.5774`
+- 최신 articulation 지표: duration template repeat `0.8750 -> 0.3750`, most common duration `0.5000 -> 0.2031`, duration bucket `3 -> 16`, velocity count `4 -> 17`
 - 기준 best-of review package: MIDI `16`, WAV `16`
 - residual-aware objective rubric: pass/fail `6 / 2`
 - validated listening input: `false`
@@ -56,6 +57,7 @@
 - bebop language strict-listen top4 bebop-selection-profile package: source package `125`, pool `1807`, selection pool `18`, selected `4`, select-after-repair `true`, selection profile `bebop_language`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.0476`, enclosure proxy `0.3516`, two-note cycle `0.0000`, interval trigram repeat `0.0123`, bar pitch-class similarity `0.5774`, max gate penalty `0.0000`
 - bebop language strict-listen top4 adjacent-repeat-final-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, select-after-repair `true`, selection profile `bebop_language`, adjacent repeat `0.0119 -> 0.0040`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.0476`, enclosure proxy `0.3438`, two-note cycle `0.0000`, interval trigram repeat `0.0123`, bar pitch-class similarity `0.5774`, max gate penalty `0.0000`
 - bebop language strict-listen top4 residual-adjacent-search-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, select-after-repair `true`, selection profile `bebop_language`, adjacent repeat `0.0040 -> 0.0000`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.0516`, enclosure proxy `0.3516`, two-note cycle `0.0000`, interval trigram repeat `0.0123`, bar pitch-class similarity `0.5774`, max gate penalty `0.0000`
+- bebop language strict-listen top4 rhythm-articulation-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, articulation accepted `4 / 4`, duration template repeat `0.8750 -> 0.3750`, most common duration `0.5000 -> 0.2031`, duration bucket `3 -> 16`, velocity count `4 -> 17`, strong-beat chord-tone `1.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`, max gate penalty `0.0000`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -90,6 +92,8 @@
 - strict-listen top4 adjacent-repeat-final-repair note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_adjacent_repeat_final_repair_note_review/bebop_language_note_review.md`
 - strict-listen top4 residual-adjacent-search-repair 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe/listen_first_by_progression/`
 - strict-listen top4 residual-adjacent-search-repair note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_residual_adjacent_search_repair_note_review/bebop_language_note_review.md`
+- strict-listen top4 rhythm-articulation-repair 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe/listen_first_by_progression/`
+- strict-listen top4 rhythm-articulation-repair note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_rhythm_articulation_repair_note_review/bebop_language_note_review.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -112,7 +116,7 @@
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py \
-  --run_id manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe \
+  --run_id manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe \
   --package_globs 'manual_2026_06_13_bebop_language_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json' \
   --selected_count 4 \
   --max_per_case 1 \
@@ -135,6 +139,7 @@
   --repair_adjacent_repeats_iterations 4 \
   --repair_large_leaps \
   --repair_large_leaps_iterations 4 \
+  --repair_rhythm_articulation \
   --min_large_leap_repair_enclosure_proxy_ratio 0.28125 \
   --max_enclosure_repair_offbeat_non_chord_ratio 0.421875 \
   --context_bass_velocity_boost 6 \
@@ -145,8 +150,8 @@
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
-  --run_id manual_2026_06_13_bebop_language_top4_residual_adjacent_search_repair_note_review \
-  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe/bebop_language_best_of_package.json \
+  --run_id manual_2026_06_13_bebop_language_top4_rhythm_articulation_repair_note_review \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe/bebop_language_best_of_package.json \
   --max_notes 32
 ```
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1408, Stage B MIDI-to-solo bebop language residual adjacent repeat repair
+- current issue: Issue #1410, Stage B MIDI-to-solo bebop language rhythm articulation repair
 - open issue queue after residual-aware listening input guard merge: `0`
 - 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
@@ -42,7 +42,7 @@
 
 2026-06-13 best-of strict consonance 기준:
 
-- latest local package: `manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe`
+- latest local package: `manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe`
 - source package count: `125`
 - candidate pool / selection pool / selected: `1807 / 18 / 4`
 - selection profile: `bebop_language`
@@ -51,13 +51,16 @@
 - large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0516 / 0.0000 / 0.3516 / 0.5774`
 - altered offbeat / two-note cycle / interval trigram repeat: `0.1250 / 0.0000 / 0.0123`
 - max gate penalty: `0.0000`
-- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe/listen_first_by_progression/`
-- note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_residual_adjacent_search_repair_note_review/bebop_language_note_review.md`
+- rhythm articulation accepted: `4 / 4`
+- duration template repeat / most common duration: `0.8750 -> 0.3750 / 0.5000 -> 0.2031`
+- duration bucket / velocity count: `3 -> 16 / 4 -> 17`
+- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe/listen_first_by_progression/`
+- note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_rhythm_articulation_repair_note_review/bebop_language_note_review.md`
 - quality claim: `false`
 - model direct claim: `false`
-- previous top4 adjacent-repeat-final package: `manual_2026_06_13_bebop_language_best_of_top4_adjacent_repeat_final_repair_probe`
-- residual adjacent-search repair delta: adjacent repeat `0.0040 -> 0.0000`, large leap `0.0476 -> 0.0516`, enclosure proxy `0.3438 -> 0.3516`
-- preserved metrics after residual adjacent-search repair: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, bar pitch-class similarity `0.5774`
+- previous top4 residual-adjacent-search package: `manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe`
+- rhythm articulation repair delta: duration template repeat `0.8750 -> 0.3750`, most common duration `0.5000 -> 0.2031`, duration bucket `3 -> 16`, velocity count `4 -> 17`
+- preserved metrics after rhythm articulation repair: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, adjacent repeat `0.0000`, bar pitch-class similarity `0.5774`
 
 2026-06-13 previous best-of strict consonance 기준:
 

--- a/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
+++ b/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import argparse
 import copy
 import json
-import shutil
 import sys
-from collections import defaultdict
+import shutil
+from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import mean
@@ -181,9 +181,14 @@ def select_candidates(rows: list[dict[str, Any]], *, selected_count: int, max_pe
 
 def aggregate_metrics(*, generated_count: int, rendered: list[dict[str, Any]], listen_first: dict[str, Any]) -> dict[str, Any]:
     metrics = [item["objective_metrics"] for item in rendered]
+    rhythm_metrics = [item.get("rhythm_articulation_metrics") or {} for item in rendered]
 
     def avg(key: str) -> float:
         return mean([float(item[key]) for item in metrics]) if metrics else 0.0
+
+    def rhythm_avg(key: str) -> float:
+        values = [float(item[key]) for item in rhythm_metrics if key in item]
+        return mean(values) if values else 0.0
 
     return {
         "generated_candidate_count": int(generated_count),
@@ -211,6 +216,14 @@ def aggregate_metrics(*, generated_count: int, rendered: list[dict[str, Any]], l
         "avg_bar_half_repeat_ratio": avg("bar_half_repeat_ratio"),
         "avg_max_bar_pitch_class_jaccard": avg("max_bar_pitch_class_jaccard"),
         "avg_bar_pitch_shape_repeat_ratio": avg("bar_pitch_shape_repeat_ratio"),
+        "avg_duration_template_repeat_ratio": rhythm_avg("duration_template_repeat_ratio"),
+        "avg_most_common_duration_ratio": rhythm_avg("most_common_duration_ratio"),
+        "avg_unique_duration_bucket_count": rhythm_avg("unique_duration_bucket_count"),
+        "avg_unique_velocity_count": rhythm_avg("unique_velocity_count"),
+        "max_offbeat_start_shift_seconds": max(
+            (float(item.get("max_offbeat_start_shift_seconds") or 0.0) for item in rhythm_metrics),
+            default=0.0,
+        ),
         "min_bar_unique_pitch_count_min": min((int(item["min_bar_unique_pitch_count"]) for item in metrics), default=0),
         "all_final_landings_chord_tone": all(bool(item["final_landing_is_chord_tone"]) for item in metrics),
     }
@@ -1010,6 +1023,129 @@ def repair_large_leaps(
     return current, current_metrics, repair_report
 
 
+def rhythm_articulation_metrics(pm: pretty_midi.PrettyMIDI, *, bars: int, bpm: float) -> dict[str, Any]:
+    notes = solo_notes(pm)
+    if not notes:
+        return {
+            "note_count": 0,
+            "duration_template_repeat_ratio": 0.0,
+            "most_common_duration_ratio": 0.0,
+            "unique_duration_bucket_count": 0,
+            "unique_velocity_count": 0,
+            "velocity_range": 0,
+            "max_offbeat_start_shift_seconds": 0.0,
+        }
+    seconds_per_beat = 60.0 / float(bpm)
+    durations = [max(0.0, float(note.end) - float(note.start)) / seconds_per_beat for note in notes]
+    duration_buckets = [round(duration, 2) for duration in durations]
+    duration_counts = Counter(duration_buckets)
+    most_common_duration_ratio = max(duration_counts.values(), default=0) / max(1, len(duration_buckets))
+    bar_templates = [
+        tuple(duration_buckets[index : index + 8])
+        for index in range(0, min(len(duration_buckets), int(bars) * 8), 8)
+        if len(duration_buckets[index : index + 8]) == 8
+    ]
+    template_counts = Counter(bar_templates)
+    duration_template_repeat_ratio = max(template_counts.values(), default=0) / max(1, len(bar_templates))
+    velocities = [int(note.velocity) for note in notes]
+    ideal_starts = []
+    for bar_index in range(int(bars)):
+        bar_start = bar_index * 4 * seconds_per_beat
+        for beat_index in range(4):
+            ideal_starts.append(bar_start + beat_index * seconds_per_beat)
+            ideal_starts.append(bar_start + (beat_index + 2 / 3) * seconds_per_beat)
+    offbeat_shifts = []
+    for index, note in enumerate(notes[: len(ideal_starts)]):
+        if index % 2 == 1:
+            offbeat_shifts.append(abs(float(note.start) - float(ideal_starts[index])))
+    return {
+        "note_count": len(notes),
+        "duration_template_repeat_ratio": float(duration_template_repeat_ratio),
+        "most_common_duration_ratio": float(most_common_duration_ratio),
+        "unique_duration_bucket_count": len(set(duration_buckets)),
+        "unique_velocity_count": len(set(velocities)),
+        "velocity_range": max(velocities) - min(velocities) if velocities else 0,
+        "max_offbeat_start_shift_seconds": max(offbeat_shifts or [0.0]),
+    }
+
+
+def apply_rhythm_articulation_variation(
+    pm: pretty_midi.PrettyMIDI,
+    *,
+    bars: int,
+    bpm: float,
+) -> tuple[pretty_midi.PrettyMIDI, dict[str, Any]]:
+    current = copy.deepcopy(pm)
+    notes = solo_notes(current)
+    before_metrics = rhythm_articulation_metrics(current, bars=bars, bpm=bpm)
+    if not notes:
+        return current, {
+            "attempted": True,
+            "changed": False,
+            "reason": "no solo notes",
+            "before": before_metrics,
+            "after": before_metrics,
+        }
+
+    seconds_per_beat = 60.0 / float(bpm)
+    total_duration = int(bars) * 4 * seconds_per_beat
+    duration_patterns = (
+        (0.78, 0.54, 0.90, 0.62, 0.74, 0.58, 0.86, 0.66),
+        (0.70, 0.68, 0.84, 0.52, 0.82, 0.60, 0.76, 0.72),
+        (0.88, 0.50, 0.76, 0.70, 0.92, 0.56, 0.80, 0.64),
+    )
+    velocity_offsets = (
+        (10, -14, 4, -10, 8, -16, 2, -8),
+        (6, -8, 12, -16, 2, -10, 10, -12),
+        (12, -18, 0, -6, 10, -12, 4, -14),
+    )
+    offbeat_shift_beats = (
+        (0.0, -0.030, 0.0, 0.018, 0.0, -0.014, 0.0, 0.024),
+        (0.0, 0.020, 0.0, -0.026, 0.0, 0.014, 0.0, -0.018),
+        (0.0, -0.018, 0.0, 0.026, 0.0, -0.024, 0.0, 0.012),
+    )
+
+    original_starts = [float(note.start) for note in notes]
+    shifted_starts: list[float] = []
+    for index, note in enumerate(notes):
+        slot = index % 8
+        bar_index = min(index // 8, int(bars) - 1)
+        pattern_index = bar_index % len(duration_patterns)
+        shift_seconds = offbeat_shift_beats[pattern_index][slot] * seconds_per_beat
+        if slot % 2 == 0:
+            shift_seconds = 0.0
+        new_start = max(0.0, min(total_duration - 0.02, original_starts[index] + shift_seconds))
+        if shifted_starts:
+            new_start = max(new_start, shifted_starts[-1] + 0.02)
+        shifted_starts.append(float(new_start))
+        note.velocity = int(max(52, min(118, int(note.velocity) + velocity_offsets[pattern_index][slot])))
+
+    for index, note in enumerate(notes):
+        slot = index % 8
+        bar_index = min(index // 8, int(bars) - 1)
+        pattern_index = bar_index % len(duration_patterns)
+        next_start = shifted_starts[index + 1] if index + 1 < len(shifted_starts) else total_duration
+        available = max(0.05, next_start - shifted_starts[index])
+        duration = max(0.055, available * duration_patterns[pattern_index][slot])
+        note.start = float(shifted_starts[index])
+        note.end = float(min(total_duration, shifted_starts[index] + duration))
+        if index + 1 < len(notes):
+            note.end = min(float(note.end), float(next_start - 0.006))
+        if index == len(notes) - 1:
+            note.end = float(total_duration)
+
+    for instrument in current.instruments:
+        instrument.notes.sort(key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+
+    after_metrics = rhythm_articulation_metrics(current, bars=bars, bpm=bpm)
+    return current, {
+        "attempted": True,
+        "changed": after_metrics != before_metrics,
+        "before": before_metrics,
+        "after": after_metrics,
+    }
+
+
 def apply_candidate_repairs(
     pm: pretty_midi.PrettyMIDI,
     item: dict[str, Any],
@@ -1183,6 +1319,7 @@ def build_best_of_package(
     repair_large_leaps_enabled: bool = False,
     repair_large_leaps_iterations: int = 4,
     min_large_leap_repair_enclosure_proxy_ratio: float = 0.28125,
+    repair_rhythm_articulation_enabled: bool = False,
     selection_profile: str = "score",
 ) -> dict[str, Any]:
     paths = package_paths(source_root, package_globs)
@@ -1292,6 +1429,56 @@ def build_best_of_package(
             repair_large_leaps_iterations=repair_large_leaps_iterations,
             min_large_leap_repair_enclosure_proxy_ratio=min_large_leap_repair_enclosure_proxy_ratio,
         )
+        rhythm_articulation_repair = {"attempted": False, "changed": False, "accepted": False}
+        if repair_rhythm_articulation_enabled:
+            candidate_pm, rhythm_articulation_repair = apply_rhythm_articulation_variation(
+                pm,
+                bars=bars,
+                bpm=bpm,
+            )
+            candidate_metrics = objective_metrics(candidate_pm, item["chords"], bars=bars, bpm=bpm)
+            candidate_gate = candidate_gate_penalty(candidate_metrics)
+            guard_passed = (
+                candidate_gate <= item_gate_penalty
+                and float(candidate_metrics["offbeat_unresolved_non_chord_ratio"])
+                <= float(item_metrics["offbeat_unresolved_non_chord_ratio"])
+                and float(candidate_metrics["offbeat_non_chord_resolution_ratio"])
+                >= float(item_metrics["offbeat_non_chord_resolution_ratio"])
+                and float(candidate_metrics["adjacent_repeat_ratio"]) <= float(item_metrics["adjacent_repeat_ratio"])
+                and float(candidate_metrics["max_bar_pitch_class_jaccard"])
+                <= max(0.72, float(item_metrics["max_bar_pitch_class_jaccard"]) + 0.01)
+            )
+            rhythm_articulation_repair["accepted"] = bool(guard_passed)
+            rhythm_articulation_repair["guard"] = {
+                "before_gate_penalty": float(item_gate_penalty),
+                "after_gate_penalty": float(candidate_gate),
+                "before_offbeat_unresolved_non_chord_ratio": float(
+                    item_metrics["offbeat_unresolved_non_chord_ratio"]
+                ),
+                "after_offbeat_unresolved_non_chord_ratio": float(
+                    candidate_metrics["offbeat_unresolved_non_chord_ratio"]
+                ),
+                "before_offbeat_non_chord_resolution_ratio": float(
+                    item_metrics["offbeat_non_chord_resolution_ratio"]
+                ),
+                "after_offbeat_non_chord_resolution_ratio": float(
+                    candidate_metrics["offbeat_non_chord_resolution_ratio"]
+                ),
+                "before_adjacent_repeat_ratio": float(item_metrics["adjacent_repeat_ratio"]),
+                "after_adjacent_repeat_ratio": float(candidate_metrics["adjacent_repeat_ratio"]),
+                "before_max_bar_pitch_class_jaccard": float(item_metrics["max_bar_pitch_class_jaccard"]),
+                "after_max_bar_pitch_class_jaccard": float(candidate_metrics["max_bar_pitch_class_jaccard"]),
+            }
+            if guard_passed:
+                pm = candidate_pm
+                item_metrics = candidate_metrics
+                item_score = candidate_score(
+                    item_metrics,
+                    target_chord_tone_ratio=target_chord_tone_ratio,
+                    target_offbeat_non_chord_ratio=target_offbeat_non_chord_ratio,
+                )
+                item_gate_penalty = candidate_gate
+        rhythm_metrics = rhythm_articulation_metrics(pm, bars=bars, bpm=bpm)
         context_pm = add_context(
             pm,
             item["chords"],
@@ -1312,6 +1499,7 @@ def build_best_of_package(
             or (repair_unresolved_offbeat_enabled and bool(unresolved_offbeat_repair.get("changed")))
             or (repair_adjacent_repeats_enabled and bool(adjacent_repeat_repair.get("changed")))
             or (repair_large_leaps_enabled and bool(large_leap_repair.get("changed")))
+            or (repair_rhythm_articulation_enabled and bool(rhythm_articulation_repair.get("accepted")))
         ):
             pm.write(str(solo_midi_path))
         else:
@@ -1328,6 +1516,8 @@ def build_best_of_package(
                 "unresolved_offbeat_repair": unresolved_offbeat_repair,
                 "adjacent_repeat_repair": adjacent_repeat_repair,
                 "large_leap_repair": large_leap_repair,
+                "rhythm_articulation_repair": rhythm_articulation_repair,
+                "rhythm_articulation_metrics": rhythm_metrics,
                 "rank": int(rank),
                 "midi_path": str(solo_midi_path),
                 "midi_sha256": sha256_file(solo_midi_path),
@@ -1371,6 +1561,7 @@ def build_best_of_package(
             "repair_adjacent_repeats_iterations": int(repair_adjacent_repeats_iterations),
             "repair_large_leaps": bool(repair_large_leaps_enabled),
             "repair_large_leaps_iterations": int(repair_large_leaps_iterations),
+            "repair_rhythm_articulation": bool(repair_rhythm_articulation_enabled),
             "min_large_leap_repair_enclosure_proxy_ratio": float(min_large_leap_repair_enclosure_proxy_ratio),
             "max_enclosure_repair_offbeat_non_chord_ratio": float(max_enclosure_repair_offbeat_non_chord_ratio),
             "context_bass_velocity_boost": int(context_bass_velocity_boost),
@@ -1432,6 +1623,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repair_adjacent_repeats_iterations", type=int, default=4)
     parser.add_argument("--repair_large_leaps", action="store_true")
     parser.add_argument("--repair_large_leaps_iterations", type=int, default=4)
+    parser.add_argument("--repair_rhythm_articulation", action="store_true")
     parser.add_argument("--min_large_leap_repair_enclosure_proxy_ratio", type=float, default=0.28125)
     parser.add_argument("--max_enclosure_repair_offbeat_non_chord_ratio", type=float, default=0.421875)
     parser.add_argument("--context_bass_velocity_boost", type=int, default=0)
@@ -1479,6 +1671,7 @@ def main() -> int:
         repair_large_leaps_enabled=bool(args.repair_large_leaps),
         repair_large_leaps_iterations=int(args.repair_large_leaps_iterations),
         min_large_leap_repair_enclosure_proxy_ratio=float(args.min_large_leap_repair_enclosure_proxy_ratio),
+        repair_rhythm_articulation_enabled=bool(args.repair_rhythm_articulation),
         max_enclosure_repair_offbeat_non_chord_ratio=float(args.max_enclosure_repair_offbeat_non_chord_ratio),
         context_bass_velocity_boost=int(args.context_bass_velocity_boost),
         context_comp_velocity_boost=int(args.context_comp_velocity_boost),

--- a/tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py
+++ b/tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py
@@ -1,0 +1,54 @@
+import unittest
+
+from scripts.build_stage_b_midi_to_solo_bebop_language_best_of_package import (
+    apply_rhythm_articulation_variation,
+    rhythm_articulation_metrics,
+)
+from scripts.build_stage_b_midi_to_solo_bebop_language_package import (
+    build_bebop_candidate,
+    candidate_gate_penalty,
+    objective_metrics,
+)
+
+
+class BebopLanguageRhythmArticulationTest(unittest.TestCase):
+    def test_reduces_duration_template_repeat_without_gate_regression(self) -> None:
+        chords = ["Dm7", "G7", "Cmaj7", "A7"]
+        pm, _meta = build_bebop_candidate(
+            chords,
+            seed=17,
+            bars=8,
+            bpm=124.0,
+            non_chord_probability=0.38,
+        )
+
+        before_rhythm = rhythm_articulation_metrics(pm, bars=8, bpm=124.0)
+        before_objective = objective_metrics(pm, chords, bars=8, bpm=124.0)
+        before_gate = candidate_gate_penalty(before_objective)
+
+        repaired, report = apply_rhythm_articulation_variation(pm, bars=8, bpm=124.0)
+        after_rhythm = rhythm_articulation_metrics(repaired, bars=8, bpm=124.0)
+        after_objective = objective_metrics(repaired, chords, bars=8, bpm=124.0)
+        after_gate = candidate_gate_penalty(after_objective)
+
+        self.assertTrue(report["attempted"])
+        self.assertTrue(report["changed"])
+        self.assertLess(
+            after_rhythm["duration_template_repeat_ratio"],
+            before_rhythm["duration_template_repeat_ratio"],
+        )
+        self.assertGreater(
+            after_rhythm["unique_duration_bucket_count"],
+            before_rhythm["unique_duration_bucket_count"],
+        )
+        self.assertGreater(
+            after_rhythm["unique_velocity_count"],
+            before_rhythm["unique_velocity_count"],
+        )
+        self.assertLessEqual(after_gate, before_gate)
+        self.assertEqual(after_objective["note_count"], before_objective["note_count"])
+        self.assertEqual(after_objective["adjacent_repeat_ratio"], before_objective["adjacent_repeat_ratio"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- strict-listen top4 rhythm articulation repair 추가
- duration/velocity/offbeat micro-shift variation 적용
- README/CURRENT_STATUS 최신 representative package 갱신

## Context
- #1408 이후 pitch/chord gate 안정화
- latest representative package adjacent repeat: `0.0000`
- observed residual issue: selected top4의 repeated duration/velocity template
- before rhythm metrics: duration template repeat `0.8750`, most common duration `0.5000`, duration bucket `3`, velocity count `4`

## Scope
- opt-in `--repair_rhythm_articulation` 플래그 추가
- selected candidate 후처리: duration pattern variation, velocity accent variation, offbeat micro-shift
- 적용 후 gate/resolution/unresolved/adjacent-repeat guard 검증
- rhythm articulation aggregate metric 추가
- focused unit test 추가

## Result
- articulation accepted: `4 / 4`
- duration template repeat: `0.8750 -> 0.3750`
- most common duration: `0.5000 -> 0.2031`
- duration bucket / velocity count: `3 -> 16 / 4 -> 17`
- max gate penalty: `0.0000`
- offbeat resolution / unresolved: `1.0000 / 0.0000`
- adjacent repeat: `0.0000`
- quality claim: `false`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_bebop_language_rhythm_articulation`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh demo`

## Risk
- objective proxy improvement only
- listening preference and musical quality claim excluded
- pitch contour remains unchanged in this issue

Closes #1410