### PR TITLE
Stage B bebop language stepwise chromatic selection repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 
 - 생성 방식: Music Transformer 계열 symbolic checkpoint + constrained decoding
 - 출력 단위: 2-8마디 solo-line MIDI 후보
-- 최신 대표 review package: strict-listen top4 rhythm-articulation-repair, MIDI `4`, WAV `4`
+- 최신 대표 review package: strict-listen top4 stepwise-chromatic-selection, MIDI `4`, WAV `4`
 - 최신 objective gate: max gate penalty `0.0000`
-- 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0516`, adjacent repeat `0.0000`, enclosure proxy `0.3516`, bar pitch-class similarity `0.5774`
+- 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3828`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0556`, adjacent repeat `0.0000`, enclosure proxy `0.3359`, bar pitch-class similarity `0.6369`
+- 최신 contour 지표: step motion `0.3849 -> 0.4048`, chromatic step `0.1905 -> 0.2183`, third/fourth motion `0.5635 -> 0.5397`
 - 최신 articulation 지표: duration template repeat `0.8750 -> 0.3750`, most common duration `0.5000 -> 0.2031`, duration bucket `3 -> 16`, velocity count `4 -> 17`
 - 기준 best-of review package: MIDI `16`, WAV `16`
 - residual-aware objective rubric: pass/fail `6 / 2`
@@ -58,6 +59,7 @@
 - bebop language strict-listen top4 adjacent-repeat-final-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, select-after-repair `true`, selection profile `bebop_language`, adjacent repeat `0.0119 -> 0.0040`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.0476`, enclosure proxy `0.3438`, two-note cycle `0.0000`, interval trigram repeat `0.0123`, bar pitch-class similarity `0.5774`, max gate penalty `0.0000`
 - bebop language strict-listen top4 residual-adjacent-search-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, select-after-repair `true`, selection profile `bebop_language`, adjacent repeat `0.0040 -> 0.0000`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.0516`, enclosure proxy `0.3516`, two-note cycle `0.0000`, interval trigram repeat `0.0123`, bar pitch-class similarity `0.5774`, max gate penalty `0.0000`
 - bebop language strict-listen top4 rhythm-articulation-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, articulation accepted `4 / 4`, duration template repeat `0.8750 -> 0.3750`, most common duration `0.5000 -> 0.2031`, duration bucket `3 -> 16`, velocity count `4 -> 17`, strong-beat chord-tone `1.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`, max gate penalty `0.0000`
+- bebop language strict-listen top4 stepwise-chromatic-selection package: source package `125`, pool `1807`, selection pool `18`, selected `4`, selection profile `bebop_stepwise_chromatic`, step motion `0.3849 -> 0.4048`, chromatic step `0.1905 -> 0.2183`, third/fourth motion `0.5635 -> 0.5397`, large leap `0.0516 -> 0.0556`, bar pitch-class similarity `0.5774 -> 0.6369`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -94,6 +96,8 @@
 - strict-listen top4 residual-adjacent-search-repair note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_residual_adjacent_search_repair_note_review/bebop_language_note_review.md`
 - strict-listen top4 rhythm-articulation-repair 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe/listen_first_by_progression/`
 - strict-listen top4 rhythm-articulation-repair note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_rhythm_articulation_repair_note_review/bebop_language_note_review.md`
+- strict-listen top4 stepwise-chromatic-selection 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe/listen_first_by_progression/`
+- strict-listen top4 stepwise-chromatic-selection note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_stepwise_chromatic_selection_note_review/bebop_language_note_review.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -116,7 +120,7 @@
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py \
-  --run_id manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe \
+  --run_id manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe \
   --package_globs 'manual_2026_06_13_bebop_language_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json' \
   --selected_count 4 \
   --max_per_case 1 \
@@ -145,13 +149,13 @@
   --context_bass_velocity_boost 6 \
   --context_comp_velocity_boost 10 \
   --select_after_repair \
-  --selection_profile bebop_language
+  --selection_profile bebop_stepwise_chromatic
 ```
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
-  --run_id manual_2026_06_13_bebop_language_top4_rhythm_articulation_repair_note_review \
-  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe/bebop_language_best_of_package.json \
+  --run_id manual_2026_06_13_bebop_language_top4_stepwise_chromatic_selection_note_review \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe/bebop_language_best_of_package.json \
   --max_notes 32
 ```
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1410, Stage B MIDI-to-solo bebop language rhythm articulation repair
+- current issue: Issue #1412, Stage B MIDI-to-solo bebop language stepwise chromatic selection repair
 - open issue queue after residual-aware listening input guard merge: `0`
 - 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
@@ -42,25 +42,27 @@
 
 2026-06-13 best-of strict consonance 기준:
 
-- latest local package: `manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe`
+- latest local package: `manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe`
 - source package count: `125`
 - candidate pool / selection pool / selected: `1807 / 18 / 4`
-- selection profile: `bebop_language`
+- selection profile: `bebop_stepwise_chromatic`
 - strong-beat chord-tone: `1.0000`
-- offbeat non-chord / resolution / unresolved: `0.3906 / 1.0000 / 0.0000`
-- large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0516 / 0.0000 / 0.3516 / 0.5774`
-- altered offbeat / two-note cycle / interval trigram repeat: `0.1250 / 0.0000 / 0.0123`
+- offbeat non-chord / resolution / unresolved: `0.3828 / 1.0000 / 0.0000`
+- large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0556 / 0.0000 / 0.3359 / 0.6369`
+- step motion / chromatic step / third-fourth motion: `0.4048 / 0.2183 / 0.5397`
+- altered offbeat / two-note cycle / interval trigram repeat: `0.1406 / 0.0000 / 0.0123`
 - max gate penalty: `0.0000`
 - rhythm articulation accepted: `4 / 4`
 - duration template repeat / most common duration: `0.8750 -> 0.3750 / 0.5000 -> 0.2031`
 - duration bucket / velocity count: `3 -> 16 / 4 -> 17`
-- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe/listen_first_by_progression/`
-- note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_rhythm_articulation_repair_note_review/bebop_language_note_review.md`
+- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe/listen_first_by_progression/`
+- note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_stepwise_chromatic_selection_note_review/bebop_language_note_review.md`
 - quality claim: `false`
 - model direct claim: `false`
-- previous top4 residual-adjacent-search package: `manual_2026_06_13_bebop_language_best_of_top4_residual_adjacent_search_repair_probe`
-- rhythm articulation repair delta: duration template repeat `0.8750 -> 0.3750`, most common duration `0.5000 -> 0.2031`, duration bucket `3 -> 16`, velocity count `4 -> 17`
-- preserved metrics after rhythm articulation repair: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, adjacent repeat `0.0000`, bar pitch-class similarity `0.5774`
+- previous top4 rhythm-articulation package: `manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe`
+- stepwise-chromatic selection delta: step motion `0.3849 -> 0.4048`, chromatic step `0.1905 -> 0.2183`, third/fourth motion `0.5635 -> 0.5397`
+- recorded tradeoff after stepwise-chromatic selection: large leap `0.0516 -> 0.0556`, bar pitch-class similarity `0.5774 -> 0.6369`, enclosure proxy `0.3516 -> 0.3359`
+- preserved metrics after stepwise-chromatic selection: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, adjacent repeat `0.0000`
 
 2026-06-13 previous best-of strict consonance 기준:
 

--- a/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
+++ b/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
@@ -268,11 +268,26 @@ def bebop_language_selection_score(item: dict[str, Any]) -> float:
     )
 
 
+def bebop_stepwise_chromatic_selection_score(item: dict[str, Any]) -> float:
+    metrics = item["objective_metrics"]
+    return (
+        bebop_language_selection_score(item)
+        + max(0.0, 0.40 - float(metrics["step_motion_ratio"])) * 2.5
+        + max(0.0, 0.22 - float(metrics["chromatic_step_ratio"])) * 3.0
+        + max(0.0, float(metrics["third_fourth_motion_ratio"]) - 0.56) * 1.0
+        + max(0.0, float(metrics["large_leap_ratio"]) - 0.09) * 2.0
+        + max(0.0, float(metrics["max_bar_pitch_class_jaccard"]) - 0.70) * 1.0
+        + max(0.0, 0.28 - float(metrics["enclosure_proxy_ratio"])) * 0.7
+    )
+
+
 def selection_sort_key(row: dict[str, Any], *, selection_profile: str) -> tuple[float, float, str, str, int]:
     if selection_profile == "score":
         primary_score = float(row["score"])
     elif selection_profile == "bebop_language":
         primary_score = bebop_language_selection_score(row)
+    elif selection_profile == "bebop_stepwise_chromatic":
+        primary_score = bebop_stepwise_chromatic_selection_score(row)
     else:
         raise BebopLanguagePackageError(f"unknown selection profile: {selection_profile}")
     return (
@@ -1629,7 +1644,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--context_bass_velocity_boost", type=int, default=0)
     parser.add_argument("--context_comp_velocity_boost", type=int, default=0)
     parser.add_argument("--select_after_repair", action="store_true")
-    parser.add_argument("--selection_profile", choices=["score", "bebop_language"], default="score")
+    parser.add_argument(
+        "--selection_profile",
+        choices=["score", "bebop_language", "bebop_stepwise_chromatic"],
+        default="score",
+    )
     return parser
 
 

--- a/tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py
+++ b/tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py
@@ -2,6 +2,7 @@ import unittest
 
 from scripts.build_stage_b_midi_to_solo_bebop_language_best_of_package import (
     apply_rhythm_articulation_variation,
+    bebop_stepwise_chromatic_selection_score,
     rhythm_articulation_metrics,
 )
 from scripts.build_stage_b_midi_to_solo_bebop_language_package import (
@@ -48,6 +49,48 @@ class BebopLanguageRhythmArticulationTest(unittest.TestCase):
         self.assertLessEqual(after_gate, before_gate)
         self.assertEqual(after_objective["note_count"], before_objective["note_count"])
         self.assertEqual(after_objective["adjacent_repeat_ratio"], before_objective["adjacent_repeat_ratio"])
+
+    def test_stepwise_chromatic_profile_prefers_stepwise_candidate(self) -> None:
+        base_metrics = {
+            "gate_penalty": 0.0,
+            "offbeat_unresolved_non_chord_ratio": 0.0,
+            "offbeat_non_chord_resolution_ratio": 1.0,
+            "large_leap_ratio": 0.05,
+            "max_abs_interval": 7,
+            "enclosure_proxy_ratio": 0.34,
+            "max_bar_pitch_class_jaccard": 0.58,
+            "adjacent_repeat_ratio": 0.0,
+            "two_note_cycle_ratio": 0.0,
+            "interval_trigram_repeat_ratio": 0.0,
+            "bar_half_repeat_ratio": 0.0,
+            "offbeat_non_chord_ratio": 0.390625,
+            "chord_tone_ratio": 0.8046875,
+            "dominant_altered_offbeat_ratio": 0.125,
+            "unique_pitch_count": 14,
+            "step_motion_ratio": 0.34,
+            "chromatic_step_ratio": 0.16,
+            "third_fourth_motion_ratio": 0.60,
+        }
+        arpeggio_like = {
+            "objective_metrics": base_metrics,
+            "score": 0.10,
+            "gate_penalty": 0.0,
+        }
+        stepwise_like = {
+            "objective_metrics": {
+                **base_metrics,
+                "step_motion_ratio": 0.42,
+                "chromatic_step_ratio": 0.24,
+                "third_fourth_motion_ratio": 0.52,
+            },
+            "score": 0.10,
+            "gate_penalty": 0.0,
+        }
+
+        self.assertLess(
+            bebop_stepwise_chromatic_selection_score(stepwise_like),
+            bebop_stepwise_chromatic_selection_score(arpeggio_like),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- stepwise/chromatic-oriented selection profile 추가
- representative top4 package와 note review 갱신
- selection scoring focused unit test 추가

## Context
- #1410 이후 rhythm articulation 적용 완료
- latest package gate/resolution/adjacent-repeat 안정화
- remaining contour issue: chord-tone/arpeggio leaning pitch contour
- previous average step/chromatic: `0.3849 / 0.1905`
- selection pool 내 gate-valid stepwise/chromatic 후보 확인

## Scope
- `bebop_stepwise_chromatic` selection profile 추가
- step/chromatic 부족, 과도한 third-fourth motion 패널티 반영
- large leap, bar similarity, enclosure tradeoff 기록
- latest README/CURRENT_STATUS package 경로 갱신

## Result
- step motion: `0.3849 -> 0.4048`
- chromatic step: `0.1905 -> 0.2183`
- third/fourth motion: `0.5635 -> 0.5397`
- max gate penalty: `0.0000`
- offbeat resolution / unresolved: `1.0000 / 0.0000`
- adjacent repeat: `0.0000`
- tradeoff: large leap `0.0516 -> 0.0556`, bar pitch-class similarity `0.5774 -> 0.6369`, enclosure `0.3516 -> 0.3359`
- quality claim: `false`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_bebop_language_rhythm_articulation`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh demo`

## Risk
- objective proxy improvement only
- selected dominant/rhythm alternatives increase some interval movement
- listening preference and musical quality claim excluded

Closes #1412