### PR TITLE
Stage B bebop language stepwise large-leap guard package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 - 생성 방식: Music Transformer 계열 symbolic checkpoint + constrained decoding
 - 출력 단위: 2-8마디 solo-line MIDI 후보
-- 최신 대표 review package: strict-listen top4 stepwise-chromatic-selection, MIDI `4`, WAV `4`
+- 최신 대표 review package: strict-listen top4 stepwise-large-leap-guard, MIDI `4`, WAV `4`
 - 최신 objective gate: max gate penalty `0.0000`
-- 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3828`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0556`, adjacent repeat `0.0000`, enclosure proxy `0.3359`, bar pitch-class similarity `0.6369`
-- 최신 contour 지표: step motion `0.3849 -> 0.4048`, chromatic step `0.1905 -> 0.2183`, third/fourth motion `0.5635 -> 0.5397`
+- 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3984`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0437`, adjacent repeat `0.0000`, enclosure proxy `0.3203`, bar pitch-class similarity `0.6131`
+- 최신 contour 지표: step motion `0.3849 -> 0.4087`, chromatic step `0.1905 -> 0.2143`, third/fourth motion `0.5635 -> 0.5476`
 - 최신 articulation 지표: duration template repeat `0.8750 -> 0.3750`, most common duration `0.5000 -> 0.2031`, duration bucket `3 -> 16`, velocity count `4 -> 17`
 - 기준 best-of review package: MIDI `16`, WAV `16`
 - residual-aware objective rubric: pass/fail `6 / 2`
@@ -60,6 +60,7 @@
 - bebop language strict-listen top4 residual-adjacent-search-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, select-after-repair `true`, selection profile `bebop_language`, adjacent repeat `0.0040 -> 0.0000`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.3906`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, large leap `0.0516`, enclosure proxy `0.3516`, two-note cycle `0.0000`, interval trigram repeat `0.0123`, bar pitch-class similarity `0.5774`, max gate penalty `0.0000`
 - bebop language strict-listen top4 rhythm-articulation-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, articulation accepted `4 / 4`, duration template repeat `0.8750 -> 0.3750`, most common duration `0.5000 -> 0.2031`, duration bucket `3 -> 16`, velocity count `4 -> 17`, strong-beat chord-tone `1.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`, max gate penalty `0.0000`
 - bebop language strict-listen top4 stepwise-chromatic-selection package: source package `125`, pool `1807`, selection pool `18`, selected `4`, selection profile `bebop_stepwise_chromatic`, step motion `0.3849 -> 0.4048`, chromatic step `0.1905 -> 0.2183`, third/fourth motion `0.5635 -> 0.5397`, large leap `0.0516 -> 0.0556`, bar pitch-class similarity `0.5774 -> 0.6369`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`
+- bebop language strict-listen top4 stepwise-large-leap-guard package: source package `125`, pool `1807`, selection pool `18`, selected `4`, selection profile `bebop_stepwise_chromatic`, large-leap repair iterations `8`, step motion `0.3849 -> 0.4087`, chromatic step `0.1905 -> 0.2143`, third/fourth motion `0.5635 -> 0.5476`, large leap `0.0556 -> 0.0437`, bar pitch-class similarity `0.6369 -> 0.6131`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -98,6 +99,8 @@
 - strict-listen top4 rhythm-articulation-repair note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_rhythm_articulation_repair_note_review/bebop_language_note_review.md`
 - strict-listen top4 stepwise-chromatic-selection 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe/listen_first_by_progression/`
 - strict-listen top4 stepwise-chromatic-selection note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_stepwise_chromatic_selection_note_review/bebop_language_note_review.md`
+- strict-listen top4 stepwise-large-leap-guard 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_large_leap_guard_probe/listen_first_by_progression/`
+- strict-listen top4 stepwise-large-leap-guard note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_stepwise_large_leap_guard_note_review/bebop_language_note_review.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -120,7 +123,7 @@
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py \
-  --run_id manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe \
+  --run_id manual_2026_06_13_bebop_language_best_of_top4_stepwise_large_leap_guard_probe \
   --package_globs 'manual_2026_06_13_bebop_language_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json' \
   --selected_count 4 \
   --max_per_case 1 \
@@ -142,7 +145,7 @@
   --repair_adjacent_repeats \
   --repair_adjacent_repeats_iterations 4 \
   --repair_large_leaps \
-  --repair_large_leaps_iterations 4 \
+  --repair_large_leaps_iterations 8 \
   --repair_rhythm_articulation \
   --min_large_leap_repair_enclosure_proxy_ratio 0.28125 \
   --max_enclosure_repair_offbeat_non_chord_ratio 0.421875 \
@@ -154,8 +157,8 @@
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
-  --run_id manual_2026_06_13_bebop_language_top4_stepwise_chromatic_selection_note_review \
-  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe/bebop_language_best_of_package.json \
+  --run_id manual_2026_06_13_bebop_language_top4_stepwise_large_leap_guard_note_review \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_large_leap_guard_probe/bebop_language_best_of_package.json \
   --max_notes 32
 ```
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1412, Stage B MIDI-to-solo bebop language stepwise chromatic selection repair
+- current issue: Issue #1414, Stage B MIDI-to-solo bebop language stepwise large-leap guard package
 - open issue queue after residual-aware listening input guard merge: `0`
 - 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
@@ -42,27 +42,27 @@
 
 2026-06-13 best-of strict consonance 기준:
 
-- latest local package: `manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe`
+- latest local package: `manual_2026_06_13_bebop_language_best_of_top4_stepwise_large_leap_guard_probe`
 - source package count: `125`
 - candidate pool / selection pool / selected: `1807 / 18 / 4`
 - selection profile: `bebop_stepwise_chromatic`
 - strong-beat chord-tone: `1.0000`
-- offbeat non-chord / resolution / unresolved: `0.3828 / 1.0000 / 0.0000`
-- large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0556 / 0.0000 / 0.3359 / 0.6369`
-- step motion / chromatic step / third-fourth motion: `0.4048 / 0.2183 / 0.5397`
-- altered offbeat / two-note cycle / interval trigram repeat: `0.1406 / 0.0000 / 0.0123`
+- offbeat non-chord / resolution / unresolved: `0.3984 / 1.0000 / 0.0000`
+- large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0437 / 0.0000 / 0.3203 / 0.6131`
+- step motion / chromatic step / third-fourth motion: `0.4087 / 0.2143 / 0.5476`
+- altered offbeat / two-note cycle / interval trigram repeat: `0.1094 / 0.0000 / 0.0123`
 - max gate penalty: `0.0000`
 - rhythm articulation accepted: `4 / 4`
 - duration template repeat / most common duration: `0.8750 -> 0.3750 / 0.5000 -> 0.2031`
 - duration bucket / velocity count: `3 -> 16 / 4 -> 17`
-- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe/listen_first_by_progression/`
-- note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_stepwise_chromatic_selection_note_review/bebop_language_note_review.md`
+- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_large_leap_guard_probe/listen_first_by_progression/`
+- note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_stepwise_large_leap_guard_note_review/bebop_language_note_review.md`
 - quality claim: `false`
 - model direct claim: `false`
-- previous top4 rhythm-articulation package: `manual_2026_06_13_bebop_language_best_of_top4_rhythm_articulation_repair_probe`
-- stepwise-chromatic selection delta: step motion `0.3849 -> 0.4048`, chromatic step `0.1905 -> 0.2183`, third/fourth motion `0.5635 -> 0.5397`
-- recorded tradeoff after stepwise-chromatic selection: large leap `0.0516 -> 0.0556`, bar pitch-class similarity `0.5774 -> 0.6369`, enclosure proxy `0.3516 -> 0.3359`
-- preserved metrics after stepwise-chromatic selection: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, adjacent repeat `0.0000`
+- previous top4 stepwise-chromatic package: `manual_2026_06_13_bebop_language_best_of_top4_stepwise_chromatic_selection_probe`
+- stepwise large-leap guard delta: large leap `0.0556 -> 0.0437`, bar pitch-class similarity `0.6369 -> 0.6131`, step motion `0.4048 -> 0.4087`
+- recorded tradeoff after large-leap guard: chromatic step `0.2183 -> 0.2143`, enclosure proxy `0.3359 -> 0.3203`, dominant altered offbeat `0.1406 -> 0.1094`
+- preserved metrics after large-leap guard: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, adjacent repeat `0.0000`
 
 2026-06-13 previous best-of strict consonance 기준:
 


### PR DESCRIPTION
## Summary
- stepwise/chromatic representative package의 large-leap tradeoff 완화
- latest README/CURRENT_STATUS package 경로와 재현 명령 갱신
- note review 경로 갱신

## Context
- #1412 이후 stepwise/chromatic contour 개선 완료
- recorded tradeoff: large leap `0.0556`, bar pitch-class similarity `0.6369`
- in-memory sweep result: `repair_large_leaps_iterations=8` 조합이 large leap와 bar similarity를 낮춤

## Scope
- representative package: `manual_2026_06_13_bebop_language_best_of_top4_stepwise_large_leap_guard_probe`
- note review: `manual_2026_06_13_bebop_language_top4_stepwise_large_leap_guard_note_review`
- README reproduction command: `--repair_large_leaps_iterations 8`
- no generated artifact upload

## Result
- large leap: `0.0556 -> 0.0437`
- bar pitch-class similarity: `0.6369 -> 0.6131`
- step motion: `0.4048 -> 0.4087`
- chromatic step: `0.2183 -> 0.2143`
- max gate penalty: `0.0000`
- offbeat resolution / unresolved: `1.0000 / 0.0000`
- adjacent repeat: `0.0000`
- quality claim: `false`

## Validation
- package generation: `manual_2026_06_13_bebop_language_best_of_top4_stepwise_large_leap_guard_probe`
- note review generation: `manual_2026_06_13_bebop_language_top4_stepwise_large_leap_guard_note_review`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk
- objective proxy improvement only
- listening preference and musical quality claim excluded
- chromatic step and enclosure proxy decreased slightly and are recorded as tradeoff

Closes #1414