### PR TITLE
Stage B bebop language top8 frontier review package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - 생성 방식: Music Transformer 계열 symbolic checkpoint + constrained decoding
 - 출력 단위: 2-8마디 solo-line MIDI 후보
 - 최신 대표 review package: strict-listen top4 stepwise-large-leap-guard, MIDI `4`, WAV `4`
+- 최신 frontier review package: strict-listen top8 stepwise-frontier, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
 - 최신 objective gate: max gate penalty `0.0000`
 - 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3984`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0437`, adjacent repeat `0.0000`, enclosure proxy `0.3203`, bar pitch-class similarity `0.6131`
 - 최신 contour 지표: step motion `0.3849 -> 0.4087`, chromatic step `0.1905 -> 0.2143`, third/fourth motion `0.5635 -> 0.5476`
@@ -61,6 +62,7 @@
 - bebop language strict-listen top4 rhythm-articulation-repair package: source package `125`, pool `1807`, selection pool `18`, selected `4`, articulation accepted `4 / 4`, duration template repeat `0.8750 -> 0.3750`, most common duration `0.5000 -> 0.2031`, duration bucket `3 -> 16`, velocity count `4 -> 17`, strong-beat chord-tone `1.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`, max gate penalty `0.0000`
 - bebop language strict-listen top4 stepwise-chromatic-selection package: source package `125`, pool `1807`, selection pool `18`, selected `4`, selection profile `bebop_stepwise_chromatic`, step motion `0.3849 -> 0.4048`, chromatic step `0.1905 -> 0.2183`, third/fourth motion `0.5635 -> 0.5397`, large leap `0.0516 -> 0.0556`, bar pitch-class similarity `0.5774 -> 0.6369`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`
 - bebop language strict-listen top4 stepwise-large-leap-guard package: source package `125`, pool `1807`, selection pool `18`, selected `4`, selection profile `bebop_stepwise_chromatic`, large-leap repair iterations `8`, step motion `0.3849 -> 0.4087`, chromatic step `0.1905 -> 0.2143`, third/fourth motion `0.5635 -> 0.5476`, large leap `0.0556 -> 0.0437`, bar pitch-class similarity `0.6369 -> 0.6131`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`
+- bebop language strict-listen top8 stepwise-frontier review package: source package `125`, pool `1807`, selection pool `18`, selected `8`, max-per-case `2`, selection profile `bebop_stepwise_chromatic`, large-leap repair iterations `8`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, step motion `0.3968`, chromatic step `0.2202`, third/fourth motion `0.5575`, large leap `0.0456`, adjacent repeat `0.0020`, bar pitch-class similarity `0.6458`, duration template repeat `0.3750`, most common duration `0.2031`, quality claim `false`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -101,6 +103,10 @@
 - strict-listen top4 stepwise-chromatic-selection note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_stepwise_chromatic_selection_note_review/bebop_language_note_review.md`
 - strict-listen top4 stepwise-large-leap-guard 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_large_leap_guard_probe/listen_first_by_progression/`
 - strict-listen top4 stepwise-large-leap-guard note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top4_stepwise_large_leap_guard_note_review/bebop_language_note_review.md`
+- strict-listen top8 stepwise-frontier 전체 context WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/audio_with_context/`
+- strict-listen top8 stepwise-frontier 전체 solo WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/audio/`
+- strict-listen top8 stepwise-frontier package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/bebop_language_best_of_package.md`
+- strict-listen top8 stepwise-frontier all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_stepwise_frontier_all_selected_note_review/bebop_language_note_review.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -159,6 +165,48 @@
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
   --run_id manual_2026_06_13_bebop_language_top4_stepwise_large_leap_guard_note_review \
   --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top4_stepwise_large_leap_guard_probe/bebop_language_best_of_package.json \
+  --max_notes 32
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py \
+  --run_id manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe \
+  --package_globs 'manual_2026_06_13_bebop_language_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json' \
+  --selected_count 8 \
+  --max_per_case 2 \
+  --bars 8 \
+  --bpm 124 \
+  --target_chord_tone_ratio 0.78 \
+  --target_offbeat_non_chord_ratio 0.38 \
+  --max_gate_penalty 0 \
+  --max_offbeat_non_chord_ratio 0.40625 \
+  --max_unresolved_offbeat_non_chord_ratio 0.03125 \
+  --max_dominant_altered_offbeat_ratio 0.25 \
+  --listen_first_mode consonance \
+  --repair_bar_similarity \
+  --repair_bar_similarity_iterations 4 \
+  --repair_enclosure_density \
+  --repair_enclosure_density_iterations 8 \
+  --repair_unresolved_offbeat \
+  --repair_unresolved_offbeat_iterations 4 \
+  --repair_adjacent_repeats \
+  --repair_adjacent_repeats_iterations 4 \
+  --repair_large_leaps \
+  --repair_large_leaps_iterations 8 \
+  --repair_rhythm_articulation \
+  --min_large_leap_repair_enclosure_proxy_ratio 0.28125 \
+  --max_enclosure_repair_offbeat_non_chord_ratio 0.421875 \
+  --context_bass_velocity_boost 6 \
+  --context_comp_velocity_boost 10 \
+  --select_after_repair \
+  --selection_profile bebop_stepwise_chromatic
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
+  --run_id manual_2026_06_13_bebop_language_top8_stepwise_frontier_all_selected_note_review \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/bebop_language_best_of_package.json \
+  --all_candidates \
   --max_notes 32
 ```
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1414, Stage B MIDI-to-solo bebop language stepwise large-leap guard package
+- current issue: Issue #1416, Stage B MIDI-to-solo bebop language top8 frontier review package
 - open issue queue after residual-aware listening input guard merge: `0`
 - 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
@@ -63,6 +63,35 @@
 - stepwise large-leap guard delta: large leap `0.0556 -> 0.0437`, bar pitch-class similarity `0.6369 -> 0.6131`, step motion `0.4048 -> 0.4087`
 - recorded tradeoff after large-leap guard: chromatic step `0.2183 -> 0.2143`, enclosure proxy `0.3359 -> 0.3203`, dominant altered offbeat `0.1406 -> 0.1094`
 - preserved metrics after large-leap guard: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, adjacent repeat `0.0000`
+
+2026-06-13 top8 frontier review package 기준:
+
+- latest frontier package: `manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe`
+- frontier role: review/yield expansion, representative replacement `false`
+- source package count: `125`
+- candidate pool / selection pool / selected: `1807 / 18 / 8`
+- max-per-case: `2`
+- selection profile: `bebop_stepwise_chromatic`
+- large-leap repair iterations: `8`
+- strong-beat chord-tone: `1.0000`
+- offbeat non-chord / resolution / unresolved: `0.3906 / 1.0000 / 0.0000`
+- large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0456 / 0.0020 / 0.3125 / 0.6458`
+- step motion / chromatic step / third-fourth motion: `0.3968 / 0.2202 / 0.5575`
+- altered offbeat / two-note cycle / interval trigram repeat: `0.1172 / 0.0000 / 0.0102`
+- max gate penalty: `0.0000`
+- duration template repeat / most common duration: `0.3750 / 0.2031`
+- duration bucket / velocity count: `16 / 17`
+- MIDI / solo WAV / context WAV: `8 / 8 / 8`
+- listen-first case count: `4`
+- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/listen_first_by_progression/`
+- all context WAV path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/audio_with_context/`
+- package report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/bebop_language_best_of_package.md`
+- all-selected note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_stepwise_frontier_all_selected_note_review/bebop_language_note_review.md`
+- all-selected note review candidate count: `8`
+- quality claim: `false`
+- model direct claim: `false`
+- recorded tradeoff against strict top4 representative: bar pitch-class similarity `0.6131 -> 0.6458`, adjacent repeat `0.0000 -> 0.0020`
+- preserved metrics against strict top4 representative: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`
 
 2026-06-13 previous best-of strict consonance 기준:
 


### PR DESCRIPTION
## Summary
- strict-listen top8 stepwise-frontier review package 기록
- README 최신 산출물, 재현 명령 추가
- CURRENT_STATUS top8 frontier 지표, tradeoff, claim boundary 추가

## Context
- #1414 stepwise large-leap guard 대표 package 기준 후보 4개 유지
- 동일 guard 조건에서 review/yield 확장 후보군 필요
- top8 frontier package는 대표 package 교체가 아니라 추가 검토 후보군

## Scope
- top8 frontier package 경로 기록
- all-selected note review 경로 기록
- source package, candidate pool, selected count, guard 지표 기록
- top4 대비 약화 지표 분리 기록

## Result
- source package: 125
- candidate pool / selection pool / selected: 1807 / 18 / 8
- MIDI / solo WAV / context WAV: 8 / 8 / 8
- max gate penalty: 0.0000
- offbeat resolution / unresolved: 1.0000 / 0.0000
- step motion / chromatic step: 0.3968 / 0.2202
- large leap / adjacent repeat: 0.0456 / 0.0020
- bar pitch-class similarity: 0.6458
- quality claim: false

## Validation
- git diff --check
- bash scripts/agent_harness.sh quick

## Risk
- representative replacement: false
- strict top4 대비 bar pitch-class similarity 약화: 0.6131 -> 0.6458
- strict top4 대비 adjacent repeat 약화: 0.0000 -> 0.0020
- listening preference, musical quality claim 제외

Closes #1416