### PR TITLE
Stage B bebop language top8 safety gate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - 생성 방식: Music Transformer 계열 symbolic checkpoint + constrained decoding
 - 출력 단위: 2-8마디 solo-line MIDI 후보
 - 최신 대표 review package: strict-listen top4 stepwise-large-leap-guard, MIDI `4`, WAV `4`
-- 최신 frontier review package: strict-listen top8 stepwise-frontier, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
+- 최신 frontier review package: strict-listen top8 safety-gate, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
 - 최신 objective gate: max gate penalty `0.0000`
 - 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3984`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0437`, adjacent repeat `0.0000`, enclosure proxy `0.3203`, bar pitch-class similarity `0.6131`
 - 최신 contour 지표: step motion `0.3849 -> 0.4087`, chromatic step `0.1905 -> 0.2143`, third/fourth motion `0.5635 -> 0.5476`
@@ -63,6 +63,7 @@
 - bebop language strict-listen top4 stepwise-chromatic-selection package: source package `125`, pool `1807`, selection pool `18`, selected `4`, selection profile `bebop_stepwise_chromatic`, step motion `0.3849 -> 0.4048`, chromatic step `0.1905 -> 0.2183`, third/fourth motion `0.5635 -> 0.5397`, large leap `0.0516 -> 0.0556`, bar pitch-class similarity `0.5774 -> 0.6369`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`
 - bebop language strict-listen top4 stepwise-large-leap-guard package: source package `125`, pool `1807`, selection pool `18`, selected `4`, selection profile `bebop_stepwise_chromatic`, large-leap repair iterations `8`, step motion `0.3849 -> 0.4087`, chromatic step `0.1905 -> 0.2143`, third/fourth motion `0.5635 -> 0.5476`, large leap `0.0556 -> 0.0437`, bar pitch-class similarity `0.6369 -> 0.6131`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`
 - bebop language strict-listen top8 stepwise-frontier review package: source package `125`, pool `1807`, selection pool `18`, selected `8`, max-per-case `2`, selection profile `bebop_stepwise_chromatic`, large-leap repair iterations `8`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, step motion `0.3968`, chromatic step `0.2202`, third/fourth motion `0.5575`, large leap `0.0456`, adjacent repeat `0.0020`, bar pitch-class similarity `0.6458`, duration template repeat `0.3750`, most common duration `0.2031`, quality claim `false`
+- bebop language strict-listen top8 safety-gate review package: source package `125`, pool `1807`, selection pool `11`, selected `8`, max-per-case `3`, max adjacent repeat `0.0000`, max bar pitch-class similarity `0.7000`, adjacent repeat `0.0020 -> 0.0000`, bar pitch-class similarity `0.6458 -> 0.6131`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, step motion `0.3968 -> 0.3790`, chromatic step `0.2202 -> 0.2044`, large leap `0.0456 -> 0.0595`, quality claim `false`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -107,6 +108,10 @@
 - strict-listen top8 stepwise-frontier 전체 solo WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/audio/`
 - strict-listen top8 stepwise-frontier package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/bebop_language_best_of_package.md`
 - strict-listen top8 stepwise-frontier all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_stepwise_frontier_all_selected_note_review/bebop_language_note_review.md`
+- strict-listen top8 safety-gate 전체 context WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/audio_with_context/`
+- strict-listen top8 safety-gate 전체 solo WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/audio/`
+- strict-listen top8 safety-gate package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/bebop_language_best_of_package.md`
+- strict-listen top8 safety-gate all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_safety_gate_all_selected_note_review/bebop_language_note_review.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -170,10 +175,10 @@
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py \
-  --run_id manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe \
+  --run_id manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe \
   --package_globs 'manual_2026_06_13_bebop_language_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json' \
   --selected_count 8 \
-  --max_per_case 2 \
+  --max_per_case 3 \
   --bars 8 \
   --bpm 124 \
   --target_chord_tone_ratio 0.78 \
@@ -182,6 +187,8 @@
   --max_offbeat_non_chord_ratio 0.40625 \
   --max_unresolved_offbeat_non_chord_ratio 0.03125 \
   --max_dominant_altered_offbeat_ratio 0.25 \
+  --max_adjacent_repeat_ratio 0 \
+  --max_bar_pitch_class_jaccard 0.70 \
   --listen_first_mode consonance \
   --repair_bar_similarity \
   --repair_bar_similarity_iterations 4 \
@@ -204,8 +211,8 @@
 
 ```bash
 .venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
-  --run_id manual_2026_06_13_bebop_language_top8_stepwise_frontier_all_selected_note_review \
-  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_stepwise_frontier_probe/bebop_language_best_of_package.json \
+  --run_id manual_2026_06_13_bebop_language_top8_safety_gate_all_selected_note_review \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/bebop_language_best_of_package.json \
   --all_candidates \
   --max_notes 32
 ```

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1416, Stage B MIDI-to-solo bebop language top8 frontier review package
+- current issue: Issue #1418, Stage B MIDI-to-solo bebop language top8 safety gate package
 - open issue queue after residual-aware listening input guard merge: `0`
 - 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
@@ -92,6 +92,37 @@
 - model direct claim: `false`
 - recorded tradeoff against strict top4 representative: bar pitch-class similarity `0.6131 -> 0.6458`, adjacent repeat `0.0000 -> 0.0020`
 - preserved metrics against strict top4 representative: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`
+
+2026-06-13 top8 safety gate package 기준:
+
+- latest safety gate package: `manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe`
+- safety gate role: frontier regression guard, representative replacement `false`
+- source package count: `125`
+- candidate pool / selection pool / selected: `1807 / 11 / 8`
+- max-per-case: `3`
+- selection profile: `bebop_stepwise_chromatic`
+- final safety gate: max adjacent repeat `0.0000`, max bar pitch-class similarity `0.7000`
+- strong-beat chord-tone: `1.0000`
+- offbeat non-chord / resolution / unresolved: `0.3867 / 1.0000 / 0.0000`
+- large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0595 / 0.0000 / 0.2969 / 0.6131`
+- step motion / chromatic step / third-fourth motion: `0.3790 / 0.2044 / 0.5615`
+- altered offbeat / two-note cycle / interval trigram repeat: `0.1016 / 0.0020 / 0.0082`
+- max gate penalty: `0.0000`
+- duration template repeat / most common duration: `0.3750 / 0.2031`
+- duration bucket / velocity count: `16 / 17`
+- MIDI / solo WAV / context WAV: `8 / 8 / 8`
+- listen-first case count: `4`
+- representative listening path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/listen_first_by_progression/`
+- all context WAV path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/audio_with_context/`
+- package report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/bebop_language_best_of_package.md`
+- all-selected note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_safety_gate_all_selected_note_review/bebop_language_note_review.md`
+- all-selected note review candidate count: `8`
+- quality claim: `false`
+- model direct claim: `false`
+- recorded improvement against top8 frontier: adjacent repeat `0.0020 -> 0.0000`, bar pitch-class similarity `0.6458 -> 0.6131`
+- recorded tradeoff against top8 frontier: max-per-case `2 -> 3`, step motion `0.3968 -> 0.3790`, chromatic step `0.2202 -> 0.2044`, large leap `0.0456 -> 0.0595`, enclosure proxy `0.3125 -> 0.2969`
+- rejected stricter case-balanced gate: max-per-case `2`, max adjacent repeat `0.0000`, max bar pitch-class similarity `0.7000-0.7200`, selectable count `7`
+- preserved metrics against top8 frontier: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`
 
 2026-06-13 previous best-of strict consonance 기준:
 

--- a/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
+++ b/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
@@ -125,6 +125,8 @@ def filter_candidate_rows(
     max_offbeat_non_chord_ratio: float | None,
     max_unresolved_offbeat_non_chord_ratio: float | None,
     max_dominant_altered_offbeat_ratio: float | None,
+    max_adjacent_repeat_ratio: float | None,
+    max_bar_pitch_class_jaccard: float | None,
 ) -> list[dict[str, Any]]:
     filtered: list[dict[str, Any]] = []
     for row in rows:
@@ -144,6 +146,16 @@ def filter_candidate_rows(
         if (
             max_dominant_altered_offbeat_ratio is not None
             and float(metrics["dominant_altered_offbeat_ratio"]) > float(max_dominant_altered_offbeat_ratio)
+        ):
+            continue
+        if (
+            max_adjacent_repeat_ratio is not None
+            and float(metrics["adjacent_repeat_ratio"]) > float(max_adjacent_repeat_ratio)
+        ):
+            continue
+        if (
+            max_bar_pitch_class_jaccard is not None
+            and float(metrics["max_bar_pitch_class_jaccard"]) > float(max_bar_pitch_class_jaccard)
         ):
             continue
         filtered.append(row)
@@ -1318,6 +1330,8 @@ def build_best_of_package(
     max_offbeat_non_chord_ratio: float | None = None,
     max_unresolved_offbeat_non_chord_ratio: float | None = None,
     max_dominant_altered_offbeat_ratio: float | None = None,
+    max_adjacent_repeat_ratio: float | None = None,
+    max_bar_pitch_class_jaccard: float | None = None,
     listen_first_mode: str = "rank",
     repair_bar_similarity_enabled: bool = False,
     repair_bar_similarity_iterations: int = 4,
@@ -1349,6 +1363,8 @@ def build_best_of_package(
         max_offbeat_non_chord_ratio=max_offbeat_non_chord_ratio,
         max_unresolved_offbeat_non_chord_ratio=max_unresolved_offbeat_non_chord_ratio,
         max_dominant_altered_offbeat_ratio=max_dominant_altered_offbeat_ratio,
+        max_adjacent_repeat_ratio=None if select_after_repair else max_adjacent_repeat_ratio,
+        max_bar_pitch_class_jaccard=None if select_after_repair else max_bar_pitch_class_jaccard,
     )
     if not selection_rows:
         raise BebopLanguagePackageError("no candidate rows after best-of selection filters")
@@ -1400,9 +1416,19 @@ def build_best_of_package(
                 }
             )
         selection_rows = sorted(
-            repaired_selection_rows,
+            filter_candidate_rows(
+                repaired_selection_rows,
+                max_gate_penalty=max_gate_penalty,
+                max_offbeat_non_chord_ratio=max_offbeat_non_chord_ratio,
+                max_unresolved_offbeat_non_chord_ratio=max_unresolved_offbeat_non_chord_ratio,
+                max_dominant_altered_offbeat_ratio=max_dominant_altered_offbeat_ratio,
+                max_adjacent_repeat_ratio=max_adjacent_repeat_ratio,
+                max_bar_pitch_class_jaccard=max_bar_pitch_class_jaccard,
+            ),
             key=lambda row: selection_sort_key(row, selection_profile=selection_profile),
         )
+        if not selection_rows:
+            raise BebopLanguagePackageError("no candidate rows after repaired best-of selection filters")
     elif selection_profile != "score":
         selection_rows = sorted(selection_rows, key=lambda row: selection_sort_key(row, selection_profile=selection_profile))
     selected = select_candidates(selection_rows, selected_count=selected_count, max_per_case=max_per_case)
@@ -1565,6 +1591,8 @@ def build_best_of_package(
             "max_offbeat_non_chord_ratio": max_offbeat_non_chord_ratio,
             "max_unresolved_offbeat_non_chord_ratio": max_unresolved_offbeat_non_chord_ratio,
             "max_dominant_altered_offbeat_ratio": max_dominant_altered_offbeat_ratio,
+            "max_adjacent_repeat_ratio": max_adjacent_repeat_ratio,
+            "max_bar_pitch_class_jaccard": max_bar_pitch_class_jaccard,
             "listen_first_mode": listen_first_mode,
             "repair_bar_similarity": bool(repair_bar_similarity_enabled),
             "repair_bar_similarity_iterations": int(repair_bar_similarity_iterations),
@@ -1627,6 +1655,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max_offbeat_non_chord_ratio", type=float, default=None)
     parser.add_argument("--max_unresolved_offbeat_non_chord_ratio", type=float, default=None)
     parser.add_argument("--max_dominant_altered_offbeat_ratio", type=float, default=None)
+    parser.add_argument("--max_adjacent_repeat_ratio", type=float, default=None)
+    parser.add_argument("--max_bar_pitch_class_jaccard", type=float, default=None)
     parser.add_argument("--listen_first_mode", choices=["rank", "consonance"], default="rank")
     parser.add_argument("--repair_bar_similarity", action="store_true")
     parser.add_argument("--repair_bar_similarity_iterations", type=int, default=4)
@@ -1678,6 +1708,8 @@ def main() -> int:
         max_offbeat_non_chord_ratio=args.max_offbeat_non_chord_ratio,
         max_unresolved_offbeat_non_chord_ratio=args.max_unresolved_offbeat_non_chord_ratio,
         max_dominant_altered_offbeat_ratio=args.max_dominant_altered_offbeat_ratio,
+        max_adjacent_repeat_ratio=args.max_adjacent_repeat_ratio,
+        max_bar_pitch_class_jaccard=args.max_bar_pitch_class_jaccard,
         listen_first_mode=str(args.listen_first_mode),
         repair_bar_similarity_enabled=bool(args.repair_bar_similarity),
         repair_bar_similarity_iterations=int(args.repair_bar_similarity_iterations),

--- a/tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py
+++ b/tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py
@@ -3,6 +3,7 @@ import unittest
 from scripts.build_stage_b_midi_to_solo_bebop_language_best_of_package import (
     apply_rhythm_articulation_variation,
     bebop_stepwise_chromatic_selection_score,
+    filter_candidate_rows,
     rhythm_articulation_metrics,
 )
 from scripts.build_stage_b_midi_to_solo_bebop_language_package import (
@@ -91,6 +92,45 @@ class BebopLanguageRhythmArticulationTest(unittest.TestCase):
             bebop_stepwise_chromatic_selection_score(stepwise_like),
             bebop_stepwise_chromatic_selection_score(arpeggio_like),
         )
+
+    def test_safety_filter_excludes_adjacent_repeat_and_bar_similarity_regressions(self) -> None:
+        base_metrics = {
+            "offbeat_non_chord_ratio": 0.390625,
+            "offbeat_unresolved_non_chord_ratio": 0.0,
+            "dominant_altered_offbeat_ratio": 0.125,
+            "adjacent_repeat_ratio": 0.0,
+            "max_bar_pitch_class_jaccard": 0.62,
+        }
+        safe = {
+            "gate_penalty": 0.0,
+            "objective_metrics": base_metrics,
+        }
+        adjacent_repeat_regression = {
+            "gate_penalty": 0.0,
+            "objective_metrics": {
+                **base_metrics,
+                "adjacent_repeat_ratio": 0.02,
+            },
+        }
+        bar_similarity_regression = {
+            "gate_penalty": 0.0,
+            "objective_metrics": {
+                **base_metrics,
+                "max_bar_pitch_class_jaccard": 0.72,
+            },
+        }
+
+        filtered = filter_candidate_rows(
+            [safe, adjacent_repeat_regression, bar_similarity_regression],
+            max_gate_penalty=0.0,
+            max_offbeat_non_chord_ratio=0.40625,
+            max_unresolved_offbeat_non_chord_ratio=0.0,
+            max_dominant_altered_offbeat_ratio=0.25,
+            max_adjacent_repeat_ratio=0.0,
+            max_bar_pitch_class_jaccard=0.625,
+        )
+
+        self.assertEqual(filtered, [safe])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- best-of builder final safety gate 옵션 추가
- adjacent repeat, bar pitch-class similarity hard filter 적용
- top8 safety-gate review package와 all-selected note review 경로 기록

## Context
- #1416 top8 frontier package 기준 후보 8개 생성
- 약화 지표: adjacent repeat 0.0020, bar pitch-class similarity 0.6458
- 기존 builder는 해당 지표를 score 벌점으로만 반영
- final review package에서는 repair 이후 metric 기준 gate 필요

## Scope
- max_adjacent_repeat_ratio 옵션 추가
- max_bar_pitch_class_jaccard 옵션 추가
- select-after-repair 경로의 post-repair filter 적용
- focused unit test 추가
- README/CURRENT_STATUS safety-gate package 기록

## Result
- package: manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe
- selected: 8
- selection pool: 11
- max-per-case: 3
- final safety gate: adjacent repeat <= 0.0000, bar pitch-class similarity <= 0.7000
- adjacent repeat: 0.0020 -> 0.0000
- bar pitch-class similarity: 0.6458 -> 0.6131
- max gate penalty: 0.0000
- offbeat resolution / unresolved: 1.0000 / 0.0000
- tradeoff: step motion 0.3968 -> 0.3790, chromatic step 0.2202 -> 0.2044, large leap 0.0456 -> 0.0595

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_bebop_language_rhythm_articulation
- package generation: manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe
- all-selected note review generation: manual_2026_06_13_bebop_language_top8_safety_gate_all_selected_note_review
- git diff --check
- bash scripts/agent_harness.sh quick
- bash scripts/agent_harness.sh demo

## Risk
- representative replacement: false
- case balance tradeoff: max-per-case 2 -> 3
- listening preference, musical quality claim 제외

Closes #1418