### PR TITLE
Stage B bebop language safety gate motion feasibility sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - 출력 단위: 2-8마디 solo-line MIDI 후보
 - 최신 대표 review package: strict-listen top4 stepwise-large-leap-guard, MIDI `4`, WAV `4`
 - 최신 frontier review package: strict-listen top8 safety-gate, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
+- 최신 feasibility sweep: safety-gate motion/leap strict filter feasible config `0`
 - 최신 objective gate: max gate penalty `0.0000`
 - 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3984`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0437`, adjacent repeat `0.0000`, enclosure proxy `0.3203`, bar pitch-class similarity `0.6131`
 - 최신 contour 지표: step motion `0.3849 -> 0.4087`, chromatic step `0.1905 -> 0.2143`, third/fourth motion `0.5635 -> 0.5476`
@@ -64,6 +65,7 @@
 - bebop language strict-listen top4 stepwise-large-leap-guard package: source package `125`, pool `1807`, selection pool `18`, selected `4`, selection profile `bebop_stepwise_chromatic`, large-leap repair iterations `8`, step motion `0.3849 -> 0.4087`, chromatic step `0.1905 -> 0.2143`, third/fourth motion `0.5635 -> 0.5476`, large leap `0.0556 -> 0.0437`, bar pitch-class similarity `0.6369 -> 0.6131`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, adjacent repeat `0.0000`
 - bebop language strict-listen top8 stepwise-frontier review package: source package `125`, pool `1807`, selection pool `18`, selected `8`, max-per-case `2`, selection profile `bebop_stepwise_chromatic`, large-leap repair iterations `8`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, step motion `0.3968`, chromatic step `0.2202`, third/fourth motion `0.5575`, large leap `0.0456`, adjacent repeat `0.0020`, bar pitch-class similarity `0.6458`, duration template repeat `0.3750`, most common duration `0.2031`, quality claim `false`
 - bebop language strict-listen top8 safety-gate review package: source package `125`, pool `1807`, selection pool `11`, selected `8`, max-per-case `3`, max adjacent repeat `0.0000`, max bar pitch-class similarity `0.7000`, adjacent repeat `0.0020 -> 0.0000`, bar pitch-class similarity `0.6458 -> 0.6131`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, step motion `0.3968 -> 0.3790`, chromatic step `0.2202 -> 0.2044`, large leap `0.0456 -> 0.0595`, quality claim `false`
+- bebop language safety-gate motion feasibility sweep: repaired pool `18`, safety baseline `11`, selectable max-per-case `2 / 3` = `7 / 9`, selected target `8`, strict motion config feasible `0`, best strict config selectable max-per-case `3` = `6`, next boundary `selection_score_reweight_or_pool_expansion`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -112,6 +114,7 @@
 - strict-listen top8 safety-gate 전체 solo WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/audio/`
 - strict-listen top8 safety-gate package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/bebop_language_best_of_package.md`
 - strict-listen top8 safety-gate all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_safety_gate_all_selected_note_review/bebop_language_note_review.md`
+- safety-gate motion feasibility sweep report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of_feasibility/manual_2026_06_13_bebop_language_top8_safety_motion_feasibility_sweep/bebop_language_safety_gate_feasibility_sweep.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -215,6 +218,11 @@
   --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/bebop_language_best_of_package.json \
   --all_candidates \
   --max_notes 32
+```
+
+```bash
+.venv/bin/python scripts/run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep.py \
+  --run_id manual_2026_06_13_bebop_language_top8_safety_motion_feasibility_sweep
 ```
 
 ```bash

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1418, Stage B MIDI-to-solo bebop language top8 safety gate package
+- current issue: Issue #1420, Stage B MIDI-to-solo bebop language safety gate motion feasibility sweep
 - open issue queue after residual-aware listening input guard merge: `0`
 - 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
@@ -123,6 +123,24 @@
 - recorded tradeoff against top8 frontier: max-per-case `2 -> 3`, step motion `0.3968 -> 0.3790`, chromatic step `0.2202 -> 0.2044`, large leap `0.0456 -> 0.0595`, enclosure proxy `0.3125 -> 0.2969`
 - rejected stricter case-balanced gate: max-per-case `2`, max adjacent repeat `0.0000`, max bar pitch-class similarity `0.7000-0.7200`, selectable count `7`
 - preserved metrics against top8 frontier: gate `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`
+
+2026-06-13 safety gate motion feasibility sweep 기준:
+
+- latest feasibility sweep: `manual_2026_06_13_bebop_language_top8_safety_motion_feasibility_sweep`
+- repaired pool count: `18`
+- safety baseline candidate count: `11`
+- safety baseline case counts: dominant_cycle `3`, major_ii_v_turnaround `1`, minor_backdoor `2`, rhythm_turnaround `5`
+- safety baseline selectable max-per-case `2 / 3`: `7 / 9`
+- selected count target: `8`
+- feasible strict motion config count: `0`
+- best strict motion config: min step `0.3600`, min chromatic `0.1800`, max large leap `0.1000`
+- best strict motion config selectable max-per-case `2 / 3`: `5 / 6`
+- report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of_feasibility/manual_2026_06_13_bebop_language_top8_safety_motion_feasibility_sweep/bebop_language_safety_gate_feasibility_sweep.md`
+- judgment: current repaired pool에서 hard filter만 추가하는 방식으로는 top8 유지와 motion/leap strictness 동시 만족 불가
+- next boundary: `selection_score_reweight_or_pool_expansion`
+- representative replacement: `false`
+- quality claim: `false`
+- model direct claim: `false`
 
 2026-06-13 previous best-of strict consonance 기준:
 

--- a/scripts/run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep.py
@@ -1,0 +1,345 @@
+"""Sweep repaired best-of candidate pool safety gates without rendering audio."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from itertools import product
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_midi_to_solo_bebop_language_best_of_package import (  # noqa: E402
+    DEFAULT_OUTPUT_ROOT,
+    apply_candidate_repairs,
+    candidate_rows,
+    filter_candidate_rows,
+    package_paths,
+    parse_globs,
+    selection_sort_key,
+)
+from scripts.build_stage_b_midi_to_solo_bebop_language_package import (  # noqa: E402
+    BebopLanguagePackageError,
+    write_json,
+    write_text,
+)
+
+
+def parse_float_grid(raw: str) -> list[float]:
+    values = [float(item.strip()) for item in str(raw or "").split(",") if item.strip()]
+    if not values:
+        raise BebopLanguagePackageError("empty float grid")
+    return values
+
+
+def parse_int_grid(raw: str) -> list[int]:
+    values = [int(item.strip()) for item in str(raw or "").split(",") if item.strip()]
+    if not values:
+        raise BebopLanguagePackageError("empty int grid")
+    return values
+
+
+def case_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
+    counts = Counter(str(row["case_label"]) for row in rows)
+    return dict(sorted(counts.items()))
+
+
+def selectable_count(counts: dict[str, int], *, max_per_case: int) -> int:
+    return sum(min(int(max_per_case), int(count)) for count in counts.values())
+
+
+def metric_average(rows: list[dict[str, Any]], key: str) -> float:
+    return mean(float(row["objective_metrics"][key]) for row in rows) if rows else 0.0
+
+
+def summarize_rows(rows: list[dict[str, Any]], *, max_per_case: int) -> dict[str, Any]:
+    counts = case_counts(rows)
+    return {
+        "candidate_count": len(rows),
+        "case_counts": counts,
+        "max_per_case": int(max_per_case),
+        "selectable_count": selectable_count(counts, max_per_case=max_per_case),
+        "avg_step_motion_ratio": metric_average(rows, "step_motion_ratio"),
+        "avg_chromatic_step_ratio": metric_average(rows, "chromatic_step_ratio"),
+        "avg_large_leap_ratio": metric_average(rows, "large_leap_ratio"),
+        "avg_adjacent_repeat_ratio": metric_average(rows, "adjacent_repeat_ratio"),
+        "avg_max_bar_pitch_class_jaccard": metric_average(rows, "max_bar_pitch_class_jaccard"),
+        "avg_enclosure_proxy_ratio": metric_average(rows, "enclosure_proxy_ratio"),
+    }
+
+
+def filter_motion_rows(
+    rows: list[dict[str, Any]],
+    *,
+    min_step_motion_ratio: float,
+    min_chromatic_step_ratio: float,
+    max_large_leap_ratio: float,
+) -> list[dict[str, Any]]:
+    filtered: list[dict[str, Any]] = []
+    for row in rows:
+        metrics = row["objective_metrics"]
+        if float(metrics["step_motion_ratio"]) < float(min_step_motion_ratio):
+            continue
+        if float(metrics["chromatic_step_ratio"]) < float(min_chromatic_step_ratio):
+            continue
+        if float(metrics["large_leap_ratio"]) > float(max_large_leap_ratio):
+            continue
+        filtered.append(row)
+    return filtered
+
+
+def build_repaired_pool(args: argparse.Namespace) -> list[dict[str, Any]]:
+    paths = package_paths(Path(args.source_root), parse_globs(str(args.package_globs)))
+    rows = candidate_rows(
+        paths=paths,
+        target_chord_tone_ratio=float(args.target_chord_tone_ratio),
+        target_offbeat_non_chord_ratio=float(args.target_offbeat_non_chord_ratio),
+    )
+    selection_rows = filter_candidate_rows(
+        rows,
+        max_gate_penalty=float(args.max_gate_penalty),
+        max_offbeat_non_chord_ratio=float(args.max_offbeat_non_chord_ratio),
+        max_unresolved_offbeat_non_chord_ratio=float(args.max_unresolved_offbeat_non_chord_ratio),
+        max_dominant_altered_offbeat_ratio=float(args.max_dominant_altered_offbeat_ratio),
+        max_adjacent_repeat_ratio=None,
+        max_bar_pitch_class_jaccard=None,
+    )
+    repaired_rows: list[dict[str, Any]] = []
+    for item in selection_rows:
+        pm = pretty_midi.PrettyMIDI(str(Path(str(item["source_midi_path"]))))
+        _pm, metrics, score, gate_penalty, *_ = apply_candidate_repairs(
+            pm,
+            item,
+            bars=int(args.bars),
+            bpm=float(args.bpm),
+            target_chord_tone_ratio=float(args.target_chord_tone_ratio),
+            target_offbeat_non_chord_ratio=float(args.target_offbeat_non_chord_ratio),
+            repair_bar_similarity_enabled=True,
+            repair_bar_similarity_iterations=int(args.repair_bar_similarity_iterations),
+            repair_enclosure_density_enabled=True,
+            repair_enclosure_density_iterations=int(args.repair_enclosure_density_iterations),
+            max_enclosure_repair_offbeat_non_chord_ratio=float(args.max_enclosure_repair_offbeat_non_chord_ratio),
+            repair_unresolved_offbeat_enabled=True,
+            repair_unresolved_offbeat_iterations=int(args.repair_unresolved_offbeat_iterations),
+            repair_adjacent_repeats_enabled=True,
+            repair_adjacent_repeats_iterations=int(args.repair_adjacent_repeats_iterations),
+            repair_large_leaps_enabled=True,
+            repair_large_leaps_iterations=int(args.repair_large_leaps_iterations),
+            min_large_leap_repair_enclosure_proxy_ratio=float(args.min_large_leap_repair_enclosure_proxy_ratio),
+        )
+        repaired_rows.append(
+            {
+                **item,
+                "objective_metrics": metrics,
+                "score": float(score),
+                "gate_penalty": float(gate_penalty),
+            }
+        )
+    return sorted(
+        repaired_rows,
+        key=lambda row: selection_sort_key(row, selection_profile=str(args.selection_profile)),
+    )
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Bebop Language Safety Gate Feasibility Sweep",
+        "",
+        "## Summary",
+        "",
+        f"- repaired candidate pool: `{summary['repaired_pool_count']}`",
+        f"- safety baseline candidate count: `{summary['safety_baseline']['candidate_count']}`",
+        f"- safety baseline selectable max-per-case 2: `{summary['safety_baseline_selectable_max_per_case_2']}`",
+        f"- safety baseline selectable max-per-case 3: `{summary['safety_baseline_selectable_max_per_case_3']}`",
+        f"- selected count target: `{summary['selected_count_target']}`",
+        f"- feasible strict motion config count: `{summary['feasible_strict_motion_config_count']}`",
+        f"- quality claim: `{str(report['quality_claimed']).lower()}`",
+        "",
+        "## Decision",
+        "",
+        f"- next boundary: `{report['decision']['next_boundary']}`",
+        f"- representative replacement: `{str(report['decision']['representative_replacement']).lower()}`",
+        "",
+        "## Top Configs",
+        "",
+    ]
+    for item in report["top_configs"][:8]:
+        lines.append(
+            "- "
+            f"step `{item['min_step_motion_ratio']:.4f}`, "
+            f"chromatic `{item['min_chromatic_step_ratio']:.4f}`, "
+            f"large-leap `{item['max_large_leap_ratio']:.4f}`, "
+            f"selectable max2 `{item['selectable_max_per_case_2']}`, "
+            f"selectable max3 `{item['selectable_max_per_case_3']}`, "
+            f"count `{item['candidate_count']}`"
+        )
+    lines.extend(["", "## Boundary", "", "- musical quality claim: `false`", "- listening preference claim: `false`"])
+    return "\n".join(lines) + "\n"
+
+
+def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
+    repaired_rows = build_repaired_pool(args)
+    safety_rows = filter_candidate_rows(
+        repaired_rows,
+        max_gate_penalty=float(args.max_gate_penalty),
+        max_offbeat_non_chord_ratio=float(args.max_offbeat_non_chord_ratio),
+        max_unresolved_offbeat_non_chord_ratio=float(args.max_unresolved_offbeat_non_chord_ratio),
+        max_dominant_altered_offbeat_ratio=float(args.max_dominant_altered_offbeat_ratio),
+        max_adjacent_repeat_ratio=float(args.max_adjacent_repeat_ratio),
+        max_bar_pitch_class_jaccard=float(args.max_bar_pitch_class_jaccard),
+    )
+    max_per_case_values = parse_int_grid(str(args.max_per_case_values))
+    step_values = parse_float_grid(str(args.min_step_motion_ratios))
+    chromatic_values = parse_float_grid(str(args.min_chromatic_step_ratios))
+    large_leap_values = parse_float_grid(str(args.max_large_leap_ratios))
+    configs: list[dict[str, Any]] = []
+    for min_step, min_chromatic, max_large_leap in product(step_values, chromatic_values, large_leap_values):
+        rows = filter_motion_rows(
+            safety_rows,
+            min_step_motion_ratio=min_step,
+            min_chromatic_step_ratio=min_chromatic,
+            max_large_leap_ratio=max_large_leap,
+        )
+        counts = case_counts(rows)
+        config = {
+            "min_step_motion_ratio": float(min_step),
+            "min_chromatic_step_ratio": float(min_chromatic),
+            "max_large_leap_ratio": float(max_large_leap),
+            "candidate_count": len(rows),
+            "case_counts": counts,
+            "feasible_for_selected_count": {},
+        }
+        for max_per_case in max_per_case_values:
+            selectable = selectable_count(counts, max_per_case=max_per_case)
+            config[f"selectable_max_per_case_{max_per_case}"] = selectable
+            config["feasible_for_selected_count"][str(max_per_case)] = selectable >= int(args.selected_count)
+        configs.append(config)
+    configs.sort(
+        key=lambda item: (
+            -max(int(item.get(f"selectable_max_per_case_{value}", 0)) for value in max_per_case_values),
+            -int(item["candidate_count"]),
+            float(item["min_step_motion_ratio"]),
+            float(item["min_chromatic_step_ratio"]),
+            float(item["max_large_leap_ratio"]),
+        )
+    )
+    feasible_count = sum(
+        1
+        for item in configs
+        if any(bool(value) for value in dict(item["feasible_for_selected_count"]).values())
+    )
+    report = {
+        "schema_version": "stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "boundary": "stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep",
+        "summary": {
+            "repaired_pool_count": len(repaired_rows),
+            "safety_baseline": summarize_rows(safety_rows, max_per_case=max(max_per_case_values)),
+            "safety_baseline_selectable_max_per_case_2": selectable_count(case_counts(safety_rows), max_per_case=2),
+            "safety_baseline_selectable_max_per_case_3": selectable_count(case_counts(safety_rows), max_per_case=3),
+            "selected_count_target": int(args.selected_count),
+            "feasible_strict_motion_config_count": feasible_count,
+        },
+        "generation": {
+            "bars": int(args.bars),
+            "bpm": float(args.bpm),
+            "target_chord_tone_ratio": float(args.target_chord_tone_ratio),
+            "target_offbeat_non_chord_ratio": float(args.target_offbeat_non_chord_ratio),
+            "max_gate_penalty": float(args.max_gate_penalty),
+            "max_offbeat_non_chord_ratio": float(args.max_offbeat_non_chord_ratio),
+            "max_unresolved_offbeat_non_chord_ratio": float(args.max_unresolved_offbeat_non_chord_ratio),
+            "max_dominant_altered_offbeat_ratio": float(args.max_dominant_altered_offbeat_ratio),
+            "max_adjacent_repeat_ratio": float(args.max_adjacent_repeat_ratio),
+            "max_bar_pitch_class_jaccard": float(args.max_bar_pitch_class_jaccard),
+            "max_per_case_values": max_per_case_values,
+            "min_step_motion_ratios": step_values,
+            "min_chromatic_step_ratios": chromatic_values,
+            "max_large_leap_ratios": large_leap_values,
+            "selection_profile": str(args.selection_profile),
+        },
+        "top_configs": configs,
+        "quality_claimed": False,
+        "model_direct_claimed": False,
+        "decision": {
+            "current_boundary": "stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep",
+            "next_boundary": "selection_score_reweight_or_pool_expansion",
+            "representative_replacement": False,
+        },
+    }
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run bebop-language safety gate feasibility sweep")
+    parser.add_argument("--source_root", default=str(DEFAULT_OUTPUT_ROOT))
+    parser.add_argument(
+        "--package_globs",
+        default=(
+            "manual_2026_06_13_bebop_language_*/bebop_language_package.json,"
+            "parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,"
+            "parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,"
+            "parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,"
+            "parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,"
+            "parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,"
+            "parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json"
+        ),
+    )
+    parser.add_argument("--output_root", default=str(DEFAULT_OUTPUT_ROOT / "best_of_feasibility"))
+    parser.add_argument("--run_id", default="")
+    parser.add_argument("--bars", type=int, default=8)
+    parser.add_argument("--bpm", type=float, default=124.0)
+    parser.add_argument("--selected_count", type=int, default=8)
+    parser.add_argument("--max_per_case_values", default="2,3")
+    parser.add_argument("--target_chord_tone_ratio", type=float, default=0.78)
+    parser.add_argument("--target_offbeat_non_chord_ratio", type=float, default=0.38)
+    parser.add_argument("--max_gate_penalty", type=float, default=0.0)
+    parser.add_argument("--max_offbeat_non_chord_ratio", type=float, default=0.40625)
+    parser.add_argument("--max_unresolved_offbeat_non_chord_ratio", type=float, default=0.03125)
+    parser.add_argument("--max_dominant_altered_offbeat_ratio", type=float, default=0.25)
+    parser.add_argument("--max_adjacent_repeat_ratio", type=float, default=0.0)
+    parser.add_argument("--max_bar_pitch_class_jaccard", type=float, default=0.70)
+    parser.add_argument("--min_step_motion_ratios", default="0.36,0.38,0.40")
+    parser.add_argument("--min_chromatic_step_ratios", default="0.18,0.20,0.22")
+    parser.add_argument("--max_large_leap_ratios", default="0.06,0.08,0.10")
+    parser.add_argument("--repair_bar_similarity_iterations", type=int, default=4)
+    parser.add_argument("--repair_enclosure_density_iterations", type=int, default=8)
+    parser.add_argument("--repair_unresolved_offbeat_iterations", type=int, default=4)
+    parser.add_argument("--repair_adjacent_repeats_iterations", type=int, default=4)
+    parser.add_argument("--repair_large_leaps_iterations", type=int, default=8)
+    parser.add_argument("--min_large_leap_repair_enclosure_proxy_ratio", type=float, default=0.28125)
+    parser.add_argument("--max_enclosure_repair_offbeat_non_chord_ratio", type=float, default=0.421875)
+    parser.add_argument(
+        "--selection_profile",
+        choices=["score", "bebop_language", "bebop_stepwise_chromatic"],
+        default="bebop_stepwise_chromatic",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    run_id = str(args.run_id or datetime.now(timezone.utc).strftime("manual_%Y_%m_%d_bebop_language_safety_%H%M%S"))
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report = run_sweep(args)
+    report["output_dir"] = str(output_dir)
+    json_path = output_dir / "bebop_language_safety_gate_feasibility_sweep.json"
+    md_path = output_dir / "bebop_language_safety_gate_feasibility_sweep.md"
+    write_json(json_path, report)
+    write_text(md_path, markdown_report(report))
+    print(json.dumps({"report_path": str(json_path), "markdown_path": str(md_path), **report["summary"]}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility.py
+++ b/tests/test_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility.py
@@ -1,0 +1,62 @@
+import unittest
+
+from scripts.run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep import (
+    case_counts,
+    filter_motion_rows,
+    selectable_count,
+    summarize_rows,
+)
+
+
+def row(case_label: str, *, step: float, chromatic: float, large_leap: float) -> dict:
+    return {
+        "case_label": case_label,
+        "objective_metrics": {
+            "step_motion_ratio": step,
+            "chromatic_step_ratio": chromatic,
+            "large_leap_ratio": large_leap,
+            "adjacent_repeat_ratio": 0.0,
+            "max_bar_pitch_class_jaccard": 0.62,
+            "enclosure_proxy_ratio": 0.31,
+        },
+    }
+
+
+class BebopLanguageSafetyGateFeasibilityTest(unittest.TestCase):
+    def test_selectable_count_caps_each_case(self) -> None:
+        counts = {"dominant_cycle": 3, "major_ii_v_turnaround": 1, "rhythm_turnaround": 5}
+
+        self.assertEqual(selectable_count(counts, max_per_case=2), 5)
+        self.assertEqual(selectable_count(counts, max_per_case=3), 7)
+
+    def test_motion_filter_requires_all_thresholds(self) -> None:
+        safe = row("dominant_cycle", step=0.40, chromatic=0.22, large_leap=0.05)
+        low_step = row("dominant_cycle", step=0.34, chromatic=0.22, large_leap=0.05)
+        low_chromatic = row("minor_backdoor", step=0.40, chromatic=0.16, large_leap=0.05)
+        high_leap = row("rhythm_turnaround", step=0.40, chromatic=0.22, large_leap=0.12)
+
+        filtered = filter_motion_rows(
+            [safe, low_step, low_chromatic, high_leap],
+            min_step_motion_ratio=0.38,
+            min_chromatic_step_ratio=0.20,
+            max_large_leap_ratio=0.08,
+        )
+
+        self.assertEqual(filtered, [safe])
+
+    def test_summary_reports_case_counts_and_metric_averages(self) -> None:
+        rows = [
+            row("dominant_cycle", step=0.40, chromatic=0.22, large_leap=0.04),
+            row("dominant_cycle", step=0.38, chromatic=0.20, large_leap=0.08),
+            row("minor_backdoor", step=0.36, chromatic=0.18, large_leap=0.06),
+        ]
+
+        summary = summarize_rows(rows, max_per_case=1)
+
+        self.assertEqual(summary["case_counts"], {"dominant_cycle": 2, "minor_backdoor": 1})
+        self.assertEqual(summary["selectable_count"], 2)
+        self.assertAlmostEqual(summary["avg_step_motion_ratio"], 0.38)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- repaired candidate pool 기반 safety gate feasibility sweep 추가
- motion floor, chromatic floor, large-leap cap 조합별 selectable count 기록
- README/CURRENT_STATUS에 sweep 결과와 다음 경계 반영

## Context
- #1418 top8 safety gate package 완료
- 개선 지표: adjacent repeat 0.0020 -> 0.0000, bar pitch-class similarity 0.6458 -> 0.6131
- tradeoff: step motion 0.3968 -> 0.3790, chromatic step 0.2202 -> 0.2044, large leap 0.0456 -> 0.0595
- 추가 hard filter만으로 top8 유지 가능한지 검증 필요

## Scope
- safety gate feasibility sweep script 추가
- selectable count helper test 추가
- sweep output path 기록
- next boundary 기록

## Result
- repaired pool: 18
- safety baseline candidate count: 11
- safety baseline case counts: dominant_cycle 3, major_ii_v_turnaround 1, minor_backdoor 2, rhythm_turnaround 5
- selectable max-per-case 2 / 3: 7 / 9
- selected target: 8
- feasible strict motion config count: 0
- best strict config: min step 0.3600, min chromatic 0.1800, max large leap 0.1000
- best strict config selectable max-per-case 2 / 3: 5 / 6
- next boundary: selection_score_reweight_or_pool_expansion

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility
- sweep execution: manual_2026_06_13_bebop_language_top8_safety_motion_feasibility_sweep
- git diff --check
- bash scripts/agent_harness.sh quick

## Risk
- objective feasibility 판단만 기록
- representative replacement: false
- listening preference, musical quality claim 제외

Closes #1420