### PR TITLE
Stage B bebop language safety motion pool expansion package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - 출력 단위: 2-8마디 solo-line MIDI 후보
 - 최신 대표 review package: strict-listen top4 stepwise-large-leap-guard, MIDI `4`, WAV `4`
 - 최신 frontier review package: strict-listen top8 safety-gate, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
+- 최신 pool expansion review package: strict-listen top8 safety-pool-expansion, representative replacement `false`
 - 최신 feasibility sweep: safety-gate motion/leap strict filter feasible config `0`
 - 최신 objective gate: max gate penalty `0.0000`
 - 최신 chord/rhythm 지표: strong-beat chord-tone `1.0000`, offbeat non-chord `0.3984`, offbeat resolution `1.0000`, unresolved offbeat `0.0000`, large leap `0.0437`, adjacent repeat `0.0000`, enclosure proxy `0.3203`, bar pitch-class similarity `0.6131`
@@ -66,6 +67,7 @@
 - bebop language strict-listen top8 stepwise-frontier review package: source package `125`, pool `1807`, selection pool `18`, selected `8`, max-per-case `2`, selection profile `bebop_stepwise_chromatic`, large-leap repair iterations `8`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, step motion `0.3968`, chromatic step `0.2202`, third/fourth motion `0.5575`, large leap `0.0456`, adjacent repeat `0.0020`, bar pitch-class similarity `0.6458`, duration template repeat `0.3750`, most common duration `0.2031`, quality claim `false`
 - bebop language strict-listen top8 safety-gate review package: source package `125`, pool `1807`, selection pool `11`, selected `8`, max-per-case `3`, max adjacent repeat `0.0000`, max bar pitch-class similarity `0.7000`, adjacent repeat `0.0020 -> 0.0000`, bar pitch-class similarity `0.6458 -> 0.6131`, max gate penalty `0.0000`, offbeat resolution `1.0000`, unresolved offbeat non-chord `0.0000`, step motion `0.3968 -> 0.3790`, chromatic step `0.2202 -> 0.2044`, large leap `0.0456 -> 0.0595`, quality claim `false`
 - bebop language safety-gate motion feasibility sweep: repaired pool `18`, safety baseline `11`, selectable max-per-case `2 / 3` = `7 / 9`, selected target `8`, strict motion config feasible `0`, best strict config selectable max-per-case `3` = `6`, next boundary `selection_score_reweight_or_pool_expansion`
+- bebop language safety motion pool expansion package: source generated `4800`, source selected `64`, best-of pool `1871`, selection pool `12`, selected `8`, max gate penalty `0.0000`, adjacent repeat `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, large leap `0.0595 -> 0.0516`, enclosure proxy `0.2969 -> 0.3086`, step motion `0.3790 -> 0.3770`, chromatic step `0.2044 -> 0.2004`, bar pitch-class similarity `0.6131 -> 0.6256`, representative replacement `false`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -115,6 +117,10 @@
 - strict-listen top8 safety-gate package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_gate_probe/bebop_language_best_of_package.md`
 - strict-listen top8 safety-gate all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_safety_gate_all_selected_note_review/bebop_language_note_review.md`
 - safety-gate motion feasibility sweep report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of_feasibility/manual_2026_06_13_bebop_language_top8_safety_motion_feasibility_sweep/bebop_language_safety_gate_feasibility_sweep.md`
+- safety motion pool expansion source package: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v23_safety_motion_pool_expansion/bebop_language_package.md`
+- strict-listen top8 safety-pool-expansion 전체 context WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_pool_expansion_probe/audio_with_context/`
+- strict-listen top8 safety-pool-expansion package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_pool_expansion_probe/bebop_language_best_of_package.md`
+- strict-listen top8 safety-pool-expansion all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_safety_pool_expansion_all_selected_note_review/bebop_language_note_review.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -223,6 +229,19 @@
 ```bash
 .venv/bin/python scripts/run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep.py \
   --run_id manual_2026_06_13_bebop_language_top8_safety_motion_feasibility_sweep
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_package.py \
+  --run_id manual_2026_06_13_bebop_language_v23_safety_motion_pool_expansion \
+  --variants_per_progression 1200 \
+  --selected_count 64 \
+  --bars 8 \
+  --bpm 124 \
+  --seed_base 5010000 \
+  --non_chord_probability 0.28 \
+  --target_chord_tone_ratio 0.78 \
+  --target_offbeat_non_chord_ratio 0.38
 ```
 
 ```bash

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1420, Stage B MIDI-to-solo bebop language safety gate motion feasibility sweep
+- current issue: Issue #1422, Stage B MIDI-to-solo bebop language safety motion pool expansion package
 - open issue queue after residual-aware listening input guard merge: `0`
 - 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
@@ -139,6 +139,32 @@
 - judgment: current repaired pool에서 hard filter만 추가하는 방식으로는 top8 유지와 motion/leap strictness 동시 만족 불가
 - next boundary: `selection_score_reweight_or_pool_expansion`
 - representative replacement: `false`
+- quality claim: `false`
+- model direct claim: `false`
+
+2026-06-13 safety motion pool expansion package 기준:
+
+- source expansion package: `manual_2026_06_13_bebop_language_v23_safety_motion_pool_expansion`
+- source generated / selected: `4800 / 64`
+- source generation: variants-per-progression `1200`, seed-base `5010000`, non-chord probability `0.28`
+- source aggregate gate max / avg: `2.0000 / 0.0811`
+- best-of package: `manual_2026_06_13_bebop_language_best_of_top8_safety_pool_expansion_probe`
+- best-of candidate pool / selection pool / selected: `1871 / 12 / 8`
+- max-per-case: `3`
+- safety gate: max adjacent repeat `0.0000`, max bar pitch-class similarity `0.7000`
+- strong-beat chord-tone: `1.0000`
+- offbeat non-chord / resolution / unresolved: `0.3828 / 1.0000 / 0.0000`
+- large leap / adjacent repeat / enclosure proxy / bar pitch-class similarity: `0.0516 / 0.0000 / 0.3086 / 0.6256`
+- step motion / chromatic step / third-fourth motion: `0.3770 / 0.2004 / 0.5714`
+- altered offbeat / two-note cycle / interval trigram repeat: `0.1172 / 0.0000 / 0.0102`
+- MIDI / solo WAV / context WAV: `8 / 8 / 8`
+- all-selected note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_safety_pool_expansion_all_selected_note_review/bebop_language_note_review.md`
+- package report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_pool_expansion_probe/bebop_language_best_of_package.md`
+- recorded improvement against top8 safety gate: large leap `0.0595 -> 0.0516`, enclosure proxy `0.2969 -> 0.3086`, dominant altered offbeat `0.1016 -> 0.1172`
+- recorded tradeoff against top8 safety gate: step motion `0.3790 -> 0.3770`, chromatic step `0.2044 -> 0.2004`, bar pitch-class similarity `0.6131 -> 0.6256`
+- preserved metrics against top8 safety gate: gate `0.0000`, adjacent repeat `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`
+- representative replacement: `false`
+- next boundary: `selection_score_reweight_with_expanded_pool_or_targeted_generation`
 - quality claim: `false`
 - model direct claim: `false`
 


### PR DESCRIPTION
## Summary
- larger source package 생성 결과 기록
- expanded source 포함 best-of safety package 결과 기록
- README/CURRENT_STATUS에 output path, 지표, representative replacement 판단 반영

## Context
- #1420 feasibility sweep 결과, hard filter 추가만으로 strict motion top8 유지 불가
- 다음 경계: selection_score_reweight_or_pool_expansion
- 이번 작업은 source pool 확장이 top8 safety package tradeoff를 줄이는지 검증

## Scope
- source expansion package 생성
- best-of safety package 재생성
- all-selected note review 생성
- large leap, enclosure, step/chromatic, bar similarity tradeoff 기록

## Result
- source package: manual_2026_06_13_bebop_language_v23_safety_motion_pool_expansion
- source generated / selected: 4800 / 64
- best-of package: manual_2026_06_13_bebop_language_best_of_top8_safety_pool_expansion_probe
- best-of pool / selection / selected: 1871 / 12 / 8
- max gate penalty: 0.0000
- adjacent repeat: 0.0000
- offbeat resolution / unresolved: 1.0000 / 0.0000
- large leap: 0.0595 -> 0.0516
- enclosure proxy: 0.2969 -> 0.3086
- step motion: 0.3790 -> 0.3770
- chromatic step: 0.2044 -> 0.2004
- bar pitch-class similarity: 0.6131 -> 0.6256
- representative replacement: false

## Validation
- source package generation: manual_2026_06_13_bebop_language_v23_safety_motion_pool_expansion
- best-of package generation: manual_2026_06_13_bebop_language_best_of_top8_safety_pool_expansion_probe
- all-selected note review generation: manual_2026_06_13_bebop_language_top8_safety_pool_expansion_all_selected_note_review
- git diff --check
- bash scripts/agent_harness.sh quick

## Risk
- local artifact reference only
- source expansion alone does not prove musical quality
- representative replacement 보류

Closes #1422