### PR TITLE
Stage B bebop language motion-balance guard feasibility sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - 최신 대표 review package: strict-listen top4 stepwise-large-leap-guard, MIDI `4`, WAV `4`
 - 최신 frontier review package: strict-listen top8 motion-balance, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
 - 최신 review handoff: motion-balance, review ready `true`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`
+- 최신 guard feasibility: motion-balance guard/motion feasible config `20`, stricter offbeat feasible `false`, stricter bar similarity feasible `true`
 - 최신 pool expansion review package: strict-listen top8 safety-pool-expansion, representative replacement `false`
 - 최신 feasibility sweep: safety-gate motion/leap strict filter feasible config `0`
 - 최신 objective gate: max gate penalty `0.0000`
@@ -71,6 +72,7 @@
 - bebop language safety motion pool expansion package: source generated `4800`, source selected `64`, best-of pool `1871`, selection pool `12`, selected `8`, max gate penalty `0.0000`, adjacent repeat `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, large leap `0.0595 -> 0.0516`, enclosure proxy `0.2969 -> 0.3086`, step motion `0.3790 -> 0.3770`, chromatic step `0.2044 -> 0.2004`, bar pitch-class similarity `0.6131 -> 0.6256`, representative replacement `false`
 - bebop language strict-listen top8 motion-balance repair package: pool `1871`, selection pool `19`, selected `8`, changed candidates `7 / 8`, pitch repair steps `26`, step motion `0.3770 -> 0.4226`, chromatic step `0.2004 -> 0.2440`, large leap `0.0516 -> 0.0437`, enclosure proxy `0.3086 -> 0.3125`, max gate penalty `0.0000`, adjacent repeat `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, bar pitch-class similarity `0.6256 -> 0.6339`, quality claim `false`
 - bebop language motion-balance review handoff: review ready `true`, selected `8`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`, baseline improved `4`, tradeoff watch `2`, unchanged guard `4`, quality claim `false`
+- bebop language motion-balance guard feasibility sweep: repaired pool `21`, safety baseline `19`, selectable max-per-case `2 / 3` = `8 / 11`, feasible guard/motion config `20`, min feasible offbeat max `0.40625`, min feasible bar similarity max `0.675`, stricter offbeat feasible `false`, stricter bar similarity feasible `true`, next `motion_balance_guard_tightening_candidate_package`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -129,6 +131,7 @@
 - strict-listen top8 motion-balance package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_motion_balance_probe/bebop_language_best_of_package.md`
 - strict-listen top8 motion-balance all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_motion_balance_all_selected_note_review/bebop_language_note_review.md`
 - strict-listen top8 motion-balance review handoff: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_motion_balance_review_handoff/bebop_language_review_handoff.md`
+- motion-balance guard feasibility sweep report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of_feasibility/manual_2026_06_13_bebop_language_motion_balance_guard_feasibility_sweep/bebop_language_safety_gate_feasibility_sweep.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -309,6 +312,26 @@
   --baseline_package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_safety_pool_expansion_probe/bebop_language_best_of_package.json \
   --note_review outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_motion_balance_all_selected_note_review/bebop_language_note_review.json \
   --expected_candidate_count 8
+```
+
+```bash
+.venv/bin/python scripts/run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep.py \
+  --run_id manual_2026_06_13_bebop_language_motion_balance_guard_feasibility_sweep \
+  --selected_count 8 \
+  --max_per_case_values 2,3 \
+  --max_offbeat_non_chord_ratio 0.40625 \
+  --max_offbeat_non_chord_ratios 0.3828125,0.390625,0.3984375,0.40625 \
+  --max_bar_pitch_class_jaccard 0.70 \
+  --max_bar_pitch_class_jaccards 0.625,0.65,0.675,0.70 \
+  --min_step_motion_ratios 0.38,0.40,0.42 \
+  --min_chromatic_step_ratios 0.20,0.22,0.24 \
+  --max_large_leap_ratios 0.045,0.055,0.065 \
+  --repair_motion_balance \
+  --repair_motion_balance_iterations 12 \
+  --target_min_step_motion_ratio 0.40 \
+  --target_min_chromatic_step_ratio 0.22 \
+  --target_max_large_leap_ratio 0.055 \
+  --max_motion_balance_bar_pitch_class_jaccard 0.70
 ```
 
 ```bash

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1426, Stage B MIDI-to-solo bebop language motion balance review handoff
+- current issue: Issue #1428, Stage B MIDI-to-solo bebop language motion-balance guard feasibility sweep
 - open issue queue after residual-aware listening input guard merge: `0`
 - 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
 
@@ -210,6 +210,28 @@
 - unchanged guard metrics: `max_gate_penalty`, `avg_adjacent_repeat_ratio`, `avg_offbeat_non_chord_resolution_ratio`, `avg_offbeat_unresolved_non_chord_ratio`
 - handoff path: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_motion_balance_review_handoff/bebop_language_review_handoff.md`
 - next boundary: `listening_review_input_or_motion_balance_guard_tightening`
+- quality claim: `false`
+- model direct claim: `false`
+
+2026-06-13 motion balance guard feasibility sweep 기준:
+
+- latest guard feasibility sweep: `manual_2026_06_13_bebop_language_motion_balance_guard_feasibility_sweep`
+- motion balance repair included: `true`
+- repaired pool count: `21`
+- safety baseline candidate count: `19`
+- safety baseline case counts: dominant_cycle `4`, major_ii_v_turnaround `4`, minor_backdoor `2`, rhythm_turnaround `9`
+- safety baseline selectable max-per-case `2 / 3`: `8 / 11`
+- selected count target: `8`
+- feasible guard/motion config count: `20`
+- feasible by max-per-case `2 / 3`: `8 / 20`
+- min feasible max offbeat non-chord: `0.40625`
+- min feasible max bar pitch-class similarity: `0.675`
+- stricter offbeat feasible: `false`
+- stricter bar similarity feasible: `true`
+- report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of_feasibility/manual_2026_06_13_bebop_language_motion_balance_guard_feasibility_sweep/bebop_language_safety_gate_feasibility_sweep.md`
+- judgment: 현 repaired pool 기준 offbeat cap 하향은 top8 유지 불가, bar similarity cap `0.675` 하향은 top8 유지 가능
+- next boundary: `motion_balance_guard_tightening_candidate_package`
+- representative replacement: `false`
 - quality claim: `false`
 - model direct claim: `false`
 

--- a/scripts/run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep.py
@@ -96,6 +96,142 @@ def filter_motion_rows(
     return filtered
 
 
+def filter_guard_rows(
+    rows: list[dict[str, Any]],
+    *,
+    max_gate_penalty: float,
+    max_offbeat_non_chord_ratio: float,
+    max_unresolved_offbeat_non_chord_ratio: float,
+    max_dominant_altered_offbeat_ratio: float,
+    max_adjacent_repeat_ratio: float,
+    max_bar_pitch_class_jaccard: float,
+) -> list[dict[str, Any]]:
+    return filter_candidate_rows(
+        rows,
+        max_gate_penalty=max_gate_penalty,
+        max_offbeat_non_chord_ratio=max_offbeat_non_chord_ratio,
+        max_unresolved_offbeat_non_chord_ratio=max_unresolved_offbeat_non_chord_ratio,
+        max_dominant_altered_offbeat_ratio=max_dominant_altered_offbeat_ratio,
+        max_adjacent_repeat_ratio=max_adjacent_repeat_ratio,
+        max_bar_pitch_class_jaccard=max_bar_pitch_class_jaccard,
+    )
+
+
+def build_guard_motion_configs(
+    rows: list[dict[str, Any]],
+    *,
+    offbeat_values: list[float],
+    bar_similarity_values: list[float],
+    step_values: list[float],
+    chromatic_values: list[float],
+    large_leap_values: list[float],
+    max_per_case_values: list[int],
+    selected_count: int,
+    max_gate_penalty: float,
+    max_unresolved_offbeat_non_chord_ratio: float,
+    max_dominant_altered_offbeat_ratio: float,
+    max_adjacent_repeat_ratio: float,
+) -> list[dict[str, Any]]:
+    configs: list[dict[str, Any]] = []
+    for max_offbeat, max_bar_similarity in product(offbeat_values, bar_similarity_values):
+        guard_rows = filter_guard_rows(
+            rows,
+            max_gate_penalty=max_gate_penalty,
+            max_offbeat_non_chord_ratio=max_offbeat,
+            max_unresolved_offbeat_non_chord_ratio=max_unresolved_offbeat_non_chord_ratio,
+            max_dominant_altered_offbeat_ratio=max_dominant_altered_offbeat_ratio,
+            max_adjacent_repeat_ratio=max_adjacent_repeat_ratio,
+            max_bar_pitch_class_jaccard=max_bar_similarity,
+        )
+        for min_step, min_chromatic, max_large_leap in product(step_values, chromatic_values, large_leap_values):
+            motion_rows = filter_motion_rows(
+                guard_rows,
+                min_step_motion_ratio=min_step,
+                min_chromatic_step_ratio=min_chromatic,
+                max_large_leap_ratio=max_large_leap,
+            )
+            counts = case_counts(motion_rows)
+            config = {
+                "max_offbeat_non_chord_ratio": float(max_offbeat),
+                "max_bar_pitch_class_jaccard": float(max_bar_similarity),
+                "min_step_motion_ratio": float(min_step),
+                "min_chromatic_step_ratio": float(min_chromatic),
+                "max_large_leap_ratio": float(max_large_leap),
+                "candidate_count": len(motion_rows),
+                "case_counts": counts,
+                "guard_candidate_count": len(guard_rows),
+                "feasible_for_selected_count": {},
+            }
+            for max_per_case in max_per_case_values:
+                selectable = selectable_count(counts, max_per_case=max_per_case)
+                config[f"selectable_max_per_case_{max_per_case}"] = selectable
+                config["feasible_for_selected_count"][str(max_per_case)] = selectable >= int(selected_count)
+            configs.append(config)
+    configs.sort(
+        key=lambda item: (
+            -max(int(item.get(f"selectable_max_per_case_{value}", 0)) for value in max_per_case_values),
+            -int(item["candidate_count"]),
+            float(item["max_offbeat_non_chord_ratio"]),
+            float(item["max_bar_pitch_class_jaccard"]),
+            float(item["min_step_motion_ratio"]),
+            float(item["min_chromatic_step_ratio"]),
+            float(item["max_large_leap_ratio"]),
+        )
+    )
+    return configs
+
+
+def summarize_feasible_configs(
+    configs: list[dict[str, Any]],
+    *,
+    baseline_max_offbeat_non_chord_ratio: float,
+    baseline_max_bar_pitch_class_jaccard: float,
+    max_per_case_values: list[int],
+) -> dict[str, Any]:
+    feasible = [
+        item
+        for item in configs
+        if any(bool(value) for value in dict(item["feasible_for_selected_count"]).values())
+    ]
+    if not feasible:
+        return {
+            "feasible_config_count": 0,
+            "min_feasible_max_offbeat_non_chord_ratio": None,
+            "min_feasible_max_bar_pitch_class_jaccard": None,
+            "stricter_offbeat_feasible": False,
+            "stricter_bar_similarity_feasible": False,
+            "feasible_by_max_per_case": {
+                str(value): 0
+                for value in max_per_case_values
+            },
+        }
+    return {
+        "feasible_config_count": len(feasible),
+        "min_feasible_max_offbeat_non_chord_ratio": min(
+            float(item["max_offbeat_non_chord_ratio"]) for item in feasible
+        ),
+        "min_feasible_max_bar_pitch_class_jaccard": min(
+            float(item["max_bar_pitch_class_jaccard"]) for item in feasible
+        ),
+        "stricter_offbeat_feasible": any(
+            float(item["max_offbeat_non_chord_ratio"]) < float(baseline_max_offbeat_non_chord_ratio)
+            for item in feasible
+        ),
+        "stricter_bar_similarity_feasible": any(
+            float(item["max_bar_pitch_class_jaccard"]) < float(baseline_max_bar_pitch_class_jaccard)
+            for item in feasible
+        ),
+        "feasible_by_max_per_case": {
+            str(value): sum(
+                1
+                for item in feasible
+                if bool(dict(item["feasible_for_selected_count"]).get(str(value), False))
+            )
+            for value in max_per_case_values
+        },
+    }
+
+
 def build_repaired_pool(args: argparse.Namespace) -> list[dict[str, Any]]:
     paths = package_paths(Path(args.source_root), parse_globs(str(args.package_globs)))
     rows = candidate_rows(
@@ -134,6 +270,12 @@ def build_repaired_pool(args: argparse.Namespace) -> list[dict[str, Any]]:
             repair_large_leaps_enabled=True,
             repair_large_leaps_iterations=int(args.repair_large_leaps_iterations),
             min_large_leap_repair_enclosure_proxy_ratio=float(args.min_large_leap_repair_enclosure_proxy_ratio),
+            repair_motion_balance_enabled=bool(args.repair_motion_balance),
+            repair_motion_balance_iterations=int(args.repair_motion_balance_iterations),
+            target_min_step_motion_ratio=float(args.target_min_step_motion_ratio),
+            target_min_chromatic_step_ratio=float(args.target_min_chromatic_step_ratio),
+            target_max_large_leap_ratio=float(args.target_max_large_leap_ratio),
+            max_motion_balance_bar_pitch_class_jaccard=float(args.max_motion_balance_bar_pitch_class_jaccard),
         )
         repaired_rows.append(
             {
@@ -161,7 +303,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- safety baseline selectable max-per-case 2: `{summary['safety_baseline_selectable_max_per_case_2']}`",
         f"- safety baseline selectable max-per-case 3: `{summary['safety_baseline_selectable_max_per_case_3']}`",
         f"- selected count target: `{summary['selected_count_target']}`",
-        f"- feasible strict motion config count: `{summary['feasible_strict_motion_config_count']}`",
+        f"- feasible guard/motion config count: `{summary['feasible_guard_motion_config_count']}`",
+        f"- min feasible offbeat max: `{summary['feasible_config_summary']['min_feasible_max_offbeat_non_chord_ratio']}`",
+        f"- min feasible bar similarity max: `{summary['feasible_config_summary']['min_feasible_max_bar_pitch_class_jaccard']}`",
+        f"- stricter offbeat feasible: `{str(summary['feasible_config_summary']['stricter_offbeat_feasible']).lower()}`",
+        f"- stricter bar similarity feasible: `{str(summary['feasible_config_summary']['stricter_bar_similarity_feasible']).lower()}`",
         f"- quality claim: `{str(report['quality_claimed']).lower()}`",
         "",
         "## Decision",
@@ -175,6 +321,8 @@ def markdown_report(report: dict[str, Any]) -> str:
     for item in report["top_configs"][:8]:
         lines.append(
             "- "
+            f"offbeat max `{item['max_offbeat_non_chord_ratio']:.4f}`, "
+            f"bar sim max `{item['max_bar_pitch_class_jaccard']:.4f}`, "
             f"step `{item['min_step_motion_ratio']:.4f}`, "
             f"chromatic `{item['min_chromatic_step_ratio']:.4f}`, "
             f"large-leap `{item['max_large_leap_ratio']:.4f}`, "
@@ -188,7 +336,7 @@ def markdown_report(report: dict[str, Any]) -> str:
 
 def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
     repaired_rows = build_repaired_pool(args)
-    safety_rows = filter_candidate_rows(
+    safety_rows = filter_guard_rows(
         repaired_rows,
         max_gate_penalty=float(args.max_gate_penalty),
         max_offbeat_non_chord_ratio=float(args.max_offbeat_non_chord_ratio),
@@ -198,44 +346,35 @@ def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
         max_bar_pitch_class_jaccard=float(args.max_bar_pitch_class_jaccard),
     )
     max_per_case_values = parse_int_grid(str(args.max_per_case_values))
+    offbeat_values = parse_float_grid(str(args.max_offbeat_non_chord_ratios))
+    bar_similarity_values = parse_float_grid(str(args.max_bar_pitch_class_jaccards))
     step_values = parse_float_grid(str(args.min_step_motion_ratios))
     chromatic_values = parse_float_grid(str(args.min_chromatic_step_ratios))
     large_leap_values = parse_float_grid(str(args.max_large_leap_ratios))
-    configs: list[dict[str, Any]] = []
-    for min_step, min_chromatic, max_large_leap in product(step_values, chromatic_values, large_leap_values):
-        rows = filter_motion_rows(
-            safety_rows,
-            min_step_motion_ratio=min_step,
-            min_chromatic_step_ratio=min_chromatic,
-            max_large_leap_ratio=max_large_leap,
-        )
-        counts = case_counts(rows)
-        config = {
-            "min_step_motion_ratio": float(min_step),
-            "min_chromatic_step_ratio": float(min_chromatic),
-            "max_large_leap_ratio": float(max_large_leap),
-            "candidate_count": len(rows),
-            "case_counts": counts,
-            "feasible_for_selected_count": {},
-        }
-        for max_per_case in max_per_case_values:
-            selectable = selectable_count(counts, max_per_case=max_per_case)
-            config[f"selectable_max_per_case_{max_per_case}"] = selectable
-            config["feasible_for_selected_count"][str(max_per_case)] = selectable >= int(args.selected_count)
-        configs.append(config)
-    configs.sort(
-        key=lambda item: (
-            -max(int(item.get(f"selectable_max_per_case_{value}", 0)) for value in max_per_case_values),
-            -int(item["candidate_count"]),
-            float(item["min_step_motion_ratio"]),
-            float(item["min_chromatic_step_ratio"]),
-            float(item["max_large_leap_ratio"]),
-        )
+    configs = build_guard_motion_configs(
+        repaired_rows,
+        offbeat_values=offbeat_values,
+        bar_similarity_values=bar_similarity_values,
+        step_values=step_values,
+        chromatic_values=chromatic_values,
+        large_leap_values=large_leap_values,
+        max_per_case_values=max_per_case_values,
+        selected_count=int(args.selected_count),
+        max_gate_penalty=float(args.max_gate_penalty),
+        max_unresolved_offbeat_non_chord_ratio=float(args.max_unresolved_offbeat_non_chord_ratio),
+        max_dominant_altered_offbeat_ratio=float(args.max_dominant_altered_offbeat_ratio),
+        max_adjacent_repeat_ratio=float(args.max_adjacent_repeat_ratio),
     )
     feasible_count = sum(
         1
         for item in configs
         if any(bool(value) for value in dict(item["feasible_for_selected_count"]).values())
+    )
+    feasible_summary = summarize_feasible_configs(
+        configs,
+        baseline_max_offbeat_non_chord_ratio=float(args.max_offbeat_non_chord_ratio),
+        baseline_max_bar_pitch_class_jaccard=float(args.max_bar_pitch_class_jaccard),
+        max_per_case_values=max_per_case_values,
     )
     report = {
         "schema_version": "stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep_v1",
@@ -247,7 +386,9 @@ def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
             "safety_baseline_selectable_max_per_case_2": selectable_count(case_counts(safety_rows), max_per_case=2),
             "safety_baseline_selectable_max_per_case_3": selectable_count(case_counts(safety_rows), max_per_case=3),
             "selected_count_target": int(args.selected_count),
-            "feasible_strict_motion_config_count": feasible_count,
+            "feasible_guard_motion_config_count": feasible_count,
+            "feasible_config_summary": feasible_summary,
+            "motion_balance_repair": bool(args.repair_motion_balance),
         },
         "generation": {
             "bars": int(args.bars),
@@ -261,9 +402,17 @@ def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
             "max_adjacent_repeat_ratio": float(args.max_adjacent_repeat_ratio),
             "max_bar_pitch_class_jaccard": float(args.max_bar_pitch_class_jaccard),
             "max_per_case_values": max_per_case_values,
+            "max_offbeat_non_chord_ratios": offbeat_values,
+            "max_bar_pitch_class_jaccards": bar_similarity_values,
             "min_step_motion_ratios": step_values,
             "min_chromatic_step_ratios": chromatic_values,
             "max_large_leap_ratios": large_leap_values,
+            "repair_motion_balance": bool(args.repair_motion_balance),
+            "repair_motion_balance_iterations": int(args.repair_motion_balance_iterations),
+            "target_min_step_motion_ratio": float(args.target_min_step_motion_ratio),
+            "target_min_chromatic_step_ratio": float(args.target_min_chromatic_step_ratio),
+            "target_max_large_leap_ratio": float(args.target_max_large_leap_ratio),
+            "max_motion_balance_bar_pitch_class_jaccard": float(args.max_motion_balance_bar_pitch_class_jaccard),
             "selection_profile": str(args.selection_profile),
         },
         "top_configs": configs,
@@ -271,7 +420,11 @@ def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
         "model_direct_claimed": False,
         "decision": {
             "current_boundary": "stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep",
-            "next_boundary": "selection_score_reweight_or_pool_expansion",
+            "next_boundary": (
+                "motion_balance_guard_tightening_candidate_package"
+                if feasible_count > 0
+                else "targeted_generation_or_pool_expansion"
+            ),
             "representative_replacement": False,
         },
     }
@@ -303,10 +456,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--target_offbeat_non_chord_ratio", type=float, default=0.38)
     parser.add_argument("--max_gate_penalty", type=float, default=0.0)
     parser.add_argument("--max_offbeat_non_chord_ratio", type=float, default=0.40625)
+    parser.add_argument("--max_offbeat_non_chord_ratios", default="0.3828125,0.390625,0.3984375,0.40625")
     parser.add_argument("--max_unresolved_offbeat_non_chord_ratio", type=float, default=0.03125)
     parser.add_argument("--max_dominant_altered_offbeat_ratio", type=float, default=0.25)
     parser.add_argument("--max_adjacent_repeat_ratio", type=float, default=0.0)
     parser.add_argument("--max_bar_pitch_class_jaccard", type=float, default=0.70)
+    parser.add_argument("--max_bar_pitch_class_jaccards", default="0.625,0.65,0.675,0.70")
     parser.add_argument("--min_step_motion_ratios", default="0.36,0.38,0.40")
     parser.add_argument("--min_chromatic_step_ratios", default="0.18,0.20,0.22")
     parser.add_argument("--max_large_leap_ratios", default="0.06,0.08,0.10")
@@ -317,6 +472,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repair_large_leaps_iterations", type=int, default=8)
     parser.add_argument("--min_large_leap_repair_enclosure_proxy_ratio", type=float, default=0.28125)
     parser.add_argument("--max_enclosure_repair_offbeat_non_chord_ratio", type=float, default=0.421875)
+    parser.add_argument("--repair_motion_balance", action="store_true")
+    parser.add_argument("--repair_motion_balance_iterations", type=int, default=12)
+    parser.add_argument("--target_min_step_motion_ratio", type=float, default=0.40)
+    parser.add_argument("--target_min_chromatic_step_ratio", type=float, default=0.22)
+    parser.add_argument("--target_max_large_leap_ratio", type=float, default=0.055)
+    parser.add_argument("--max_motion_balance_bar_pitch_class_jaccard", type=float, default=0.70)
     parser.add_argument(
         "--selection_profile",
         choices=["score", "bebop_language", "bebop_stepwise_chromatic"],

--- a/tests/test_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility.py
+++ b/tests/test_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility.py
@@ -1,23 +1,38 @@
 import unittest
 
 from scripts.run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep import (
+    build_guard_motion_configs,
     case_counts,
+    filter_guard_rows,
     filter_motion_rows,
     selectable_count,
+    summarize_feasible_configs,
     summarize_rows,
 )
 
 
-def row(case_label: str, *, step: float, chromatic: float, large_leap: float) -> dict:
+def row(
+    case_label: str,
+    *,
+    step: float,
+    chromatic: float,
+    large_leap: float,
+    offbeat: float = 0.390625,
+    bar_similarity: float = 0.62,
+) -> dict:
     return {
+        "gate_penalty": 0.0,
         "case_label": case_label,
         "objective_metrics": {
             "step_motion_ratio": step,
             "chromatic_step_ratio": chromatic,
             "large_leap_ratio": large_leap,
             "adjacent_repeat_ratio": 0.0,
-            "max_bar_pitch_class_jaccard": 0.62,
+            "max_bar_pitch_class_jaccard": bar_similarity,
             "enclosure_proxy_ratio": 0.31,
+            "offbeat_non_chord_ratio": offbeat,
+            "offbeat_unresolved_non_chord_ratio": 0.0,
+            "dominant_altered_offbeat_ratio": 0.125,
         },
     }
 
@@ -56,6 +71,74 @@ class BebopLanguageSafetyGateFeasibilityTest(unittest.TestCase):
         self.assertEqual(summary["case_counts"], {"dominant_cycle": 2, "minor_backdoor": 1})
         self.assertEqual(summary["selectable_count"], 2)
         self.assertAlmostEqual(summary["avg_step_motion_ratio"], 0.38)
+
+    def test_guard_filter_applies_offbeat_and_bar_similarity_caps(self) -> None:
+        safe = row("dominant_cycle", step=0.40, chromatic=0.22, large_leap=0.04)
+        high_offbeat = row("minor_backdoor", step=0.40, chromatic=0.22, large_leap=0.04, offbeat=0.40625)
+        high_bar_similarity = row(
+            "rhythm_turnaround",
+            step=0.40,
+            chromatic=0.22,
+            large_leap=0.04,
+            bar_similarity=0.68,
+        )
+
+        filtered = filter_guard_rows(
+            [safe, high_offbeat, high_bar_similarity],
+            max_gate_penalty=0.0,
+            max_offbeat_non_chord_ratio=0.390625,
+            max_unresolved_offbeat_non_chord_ratio=0.0,
+            max_dominant_altered_offbeat_ratio=0.25,
+            max_adjacent_repeat_ratio=0.0,
+            max_bar_pitch_class_jaccard=0.65,
+        )
+
+        self.assertEqual(filtered, [safe])
+
+    def test_guard_motion_configs_report_selected_count_feasibility(self) -> None:
+        rows = [
+            row("dominant_cycle", step=0.42, chromatic=0.24, large_leap=0.04),
+            row("dominant_cycle", step=0.41, chromatic=0.23, large_leap=0.04),
+            row("minor_backdoor", step=0.40, chromatic=0.22, large_leap=0.05),
+            row("rhythm_turnaround", step=0.40, chromatic=0.22, large_leap=0.05, offbeat=0.40625),
+        ]
+
+        configs = build_guard_motion_configs(
+            rows,
+            offbeat_values=[0.390625, 0.40625],
+            bar_similarity_values=[0.65],
+            step_values=[0.40],
+            chromatic_values=[0.22],
+            large_leap_values=[0.055],
+            max_per_case_values=[1, 2],
+            selected_count=4,
+            max_gate_penalty=0.0,
+            max_unresolved_offbeat_non_chord_ratio=0.0,
+            max_dominant_altered_offbeat_ratio=0.25,
+            max_adjacent_repeat_ratio=0.0,
+        )
+
+        strict_offbeat = next(item for item in configs if item["max_offbeat_non_chord_ratio"] == 0.390625)
+        relaxed_offbeat = next(item for item in configs if item["max_offbeat_non_chord_ratio"] == 0.40625)
+        self.assertFalse(strict_offbeat["feasible_for_selected_count"]["1"])
+        self.assertFalse(strict_offbeat["feasible_for_selected_count"]["2"])
+        self.assertFalse(relaxed_offbeat["feasible_for_selected_count"]["1"])
+        self.assertTrue(relaxed_offbeat["feasible_for_selected_count"]["2"])
+        self.assertGreater(
+            relaxed_offbeat["candidate_count"],
+            strict_offbeat["candidate_count"],
+        )
+
+        summary = summarize_feasible_configs(
+            configs,
+            baseline_max_offbeat_non_chord_ratio=0.40625,
+            baseline_max_bar_pitch_class_jaccard=0.70,
+            max_per_case_values=[1, 2],
+        )
+        self.assertEqual(summary["min_feasible_max_offbeat_non_chord_ratio"], 0.40625)
+        self.assertEqual(summary["min_feasible_max_bar_pitch_class_jaccard"], 0.65)
+        self.assertFalse(summary["stricter_offbeat_feasible"])
+        self.assertTrue(summary["stricter_bar_similarity_feasible"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- safety gate feasibility sweep에 motion-balance repair 옵션 추가
- offbeat non-chord max, bar pitch-class similarity max grid 추가
- stricter guard의 top8 유지 가능 여부 기록
- README/CURRENT_STATUS에 sweep 결과 반영

## Context
- #1426 handoff 결과 motion-balance package는 review ready `true`
- baseline 대비 개선: step/chromatic/large-leap/enclosure
- tradeoff watch: offbeat non-chord `0.3828 -> 0.4063`, bar pitch-class similarity `0.6256 -> 0.6339`
- 기존 feasibility sweep는 motion-balance repair와 offbeat/bar guard grid 미반영

## Scope
- repaired pool 생성 단계의 motion-balance repair 반영
- offbeat/bar guard grid 별 candidate count, case count, selectable count 계산
- feasible config summary 추가
- stricter offbeat/bar feasibility 판단 기록

## Result
- repaired pool: `21`
- safety baseline candidate count: `19`
- selectable max-per-case `2 / 3`: `8 / 11`
- feasible guard/motion config count: `20`
- min feasible max offbeat non-chord: `0.40625`
- min feasible max bar pitch-class similarity: `0.675`
- stricter offbeat feasible: `false`
- stricter bar similarity feasible: `true`
- next boundary: `motion_balance_guard_tightening_candidate_package`

## Validation
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility_sweep.py`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_bebop_language_safety_gate_feasibility`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh demo`

## Risk
- objective feasibility 기준
- audio/listening quality claim 없음
- offbeat cap 하향은 현 repaired pool 기준 top8 유지 불가

Closes #1428
