### PR TITLE
Stage B bebop language targeted offbeat pool expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 - 생성 방식: Music Transformer 계열 symbolic checkpoint + constrained decoding
 - 출력 단위: 2-8마디 solo-line MIDI 후보
 - 최신 대표 review package: strict-listen top4 stepwise-large-leap-guard, MIDI `4`, WAV `4`
-- 최신 frontier review package: strict-listen top8 motion-balance, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
-- 최신 review handoff: motion-balance, review ready `true`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`
+- 최신 frontier review package: strict-listen top8 targeted-low-offbeat, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
+- 최신 offbeat 개선: offbeat non-chord `0.4063 -> 0.3711`, resolution `1.0000`, unresolved `0.0000`
+- 최신 review handoff: targeted-low-offbeat, review ready `true`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`
 - 최신 guard feasibility: motion-balance guard/motion feasible config `20`, stricter offbeat feasible `false`, stricter bar similarity feasible `true`
 - 최신 pool expansion review package: strict-listen top8 safety-pool-expansion, representative replacement `false`
 - 최신 feasibility sweep: safety-gate motion/leap strict filter feasible config `0`
@@ -73,6 +74,7 @@
 - bebop language strict-listen top8 motion-balance repair package: pool `1871`, selection pool `19`, selected `8`, changed candidates `7 / 8`, pitch repair steps `26`, step motion `0.3770 -> 0.4226`, chromatic step `0.2004 -> 0.2440`, large leap `0.0516 -> 0.0437`, enclosure proxy `0.3086 -> 0.3125`, max gate penalty `0.0000`, adjacent repeat `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, bar pitch-class similarity `0.6256 -> 0.6339`, quality claim `false`
 - bebop language motion-balance review handoff: review ready `true`, selected `8`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`, baseline improved `4`, tradeoff watch `2`, unchanged guard `4`, quality claim `false`
 - bebop language motion-balance guard feasibility sweep: repaired pool `21`, safety baseline `19`, selectable max-per-case `2 / 3` = `8 / 11`, feasible guard/motion config `20`, min feasible offbeat max `0.40625`, min feasible bar similarity max `0.675`, stricter offbeat feasible `false`, stricter bar similarity feasible `true`, next `motion_balance_guard_tightening_candidate_package`
+- bebop language targeted-low-offbeat package: generated candidate pool `1999`, selected `8`, max gate penalty `0.0000`, offbeat non-chord `0.4063 -> 0.3711`, offbeat resolution `1.0000`, unresolved `0.0000`, step motion `0.4226 -> 0.4345`, chromatic step `0.2440 -> 0.2401`, large leap `0.0437 -> 0.0437`, enclosure proxy `0.3125 -> 0.3242`, bar pitch-class similarity `0.6339 -> 0.6429`, motion-balance changed candidates `8 / 8`, pitch repair steps `36`, quality claim `false`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -132,6 +134,12 @@
 - strict-listen top8 motion-balance all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_motion_balance_all_selected_note_review/bebop_language_note_review.md`
 - strict-listen top8 motion-balance review handoff: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_motion_balance_review_handoff/bebop_language_review_handoff.md`
 - motion-balance guard feasibility sweep report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of_feasibility/manual_2026_06_13_bebop_language_motion_balance_guard_feasibility_sweep/bebop_language_safety_gate_feasibility_sweep.md`
+- targeted-low-offbeat source package: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v24_targeted_low_offbeat_pool/bebop_language_package.md`
+- targeted-low-offbeat top8 전체 context WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/audio_with_context/`
+- targeted-low-offbeat top8 전체 solo WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/audio/`
+- targeted-low-offbeat top8 package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/bebop_language_best_of_package.md`
+- targeted-low-offbeat top8 all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_dedup_all_selected_note_review/bebop_language_note_review.md`
+- targeted-low-offbeat review handoff: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_targeted_low_offbeat_review_handoff/bebop_language_review_handoff.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -332,6 +340,78 @@
   --target_min_chromatic_step_ratio 0.22 \
   --target_max_large_leap_ratio 0.055 \
   --max_motion_balance_bar_pitch_class_jaccard 0.70
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_package.py \
+  --run_id manual_2026_06_13_bebop_language_v24_targeted_low_offbeat_pool \
+  --variants_per_progression 1000 \
+  --selected_count 128 \
+  --seed_base 6100000 \
+  --non_chord_probability 0.08 \
+  --target_chord_tone_ratio 0.82 \
+  --target_offbeat_non_chord_ratio 0.30 \
+  --bars 8 \
+  --bpm 124
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py \
+  --run_id manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe \
+  --package_globs 'manual_2026_06_13_bebop_language_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json' \
+  --selected_count 8 \
+  --max_per_case 3 \
+  --bars 8 \
+  --bpm 124 \
+  --target_chord_tone_ratio 0.82 \
+  --target_offbeat_non_chord_ratio 0.34 \
+  --max_gate_penalty 1.0 \
+  --max_offbeat_non_chord_ratio 0.390625 \
+  --max_unresolved_offbeat_non_chord_ratio 0.10 \
+  --max_dominant_altered_offbeat_ratio 0.25 \
+  --max_adjacent_repeat_ratio 0 \
+  --max_bar_pitch_class_jaccard 0.675 \
+  --listen_first_mode consonance \
+  --repair_bar_similarity \
+  --repair_bar_similarity_iterations 4 \
+  --repair_enclosure_density \
+  --repair_enclosure_density_iterations 8 \
+  --repair_unresolved_offbeat \
+  --repair_unresolved_offbeat_iterations 8 \
+  --repair_adjacent_repeats \
+  --repair_adjacent_repeats_iterations 4 \
+  --repair_large_leaps \
+  --repair_large_leaps_iterations 8 \
+  --repair_motion_balance \
+  --repair_motion_balance_iterations 12 \
+  --target_min_step_motion_ratio 0.40 \
+  --target_min_chromatic_step_ratio 0.22 \
+  --target_max_large_leap_ratio 0.055 \
+  --max_motion_balance_bar_pitch_class_jaccard 0.675 \
+  --repair_rhythm_articulation \
+  --min_large_leap_repair_enclosure_proxy_ratio 0.28125 \
+  --max_enclosure_repair_offbeat_non_chord_ratio 0.421875 \
+  --context_bass_velocity_boost 6 \
+  --context_comp_velocity_boost 10 \
+  --select_after_repair \
+  --selection_profile bebop_stepwise_chromatic
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
+  --run_id manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_dedup_all_selected_note_review \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/bebop_language_best_of_package.json \
+  --all_candidates \
+  --max_notes 32
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_review_handoff.py \
+  --run_id manual_2026_06_13_bebop_language_targeted_low_offbeat_review_handoff \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/bebop_language_best_of_package.json \
+  --baseline_package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_motion_balance_probe/bebop_language_best_of_package.json \
+  --note_review outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_dedup_all_selected_note_review/bebop_language_note_review.json \
+  --expected_candidate_count 8
 ```
 
 ```bash

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,9 +22,9 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1428, Stage B MIDI-to-solo bebop language motion-balance guard feasibility sweep
+- current issue: Issue #1430, Stage B MIDI-to-solo bebop language targeted offbeat pool expansion
 - open issue queue after residual-aware listening input guard merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo residual-aware user listening review fill`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted-low-offbeat listening review or case-balance repair`
 
 현재 범위가 아닌 것:
 
@@ -231,6 +231,42 @@
 - report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of_feasibility/manual_2026_06_13_bebop_language_motion_balance_guard_feasibility_sweep/bebop_language_safety_gate_feasibility_sweep.md`
 - judgment: 현 repaired pool 기준 offbeat cap 하향은 top8 유지 불가, bar similarity cap `0.675` 하향은 top8 유지 가능
 - next boundary: `motion_balance_guard_tightening_candidate_package`
+- representative replacement: `false`
+- quality claim: `false`
+- model direct claim: `false`
+
+2026-06-13 targeted low-offbeat package 기준:
+
+- source attempt package: `manual_2026_06_13_bebop_language_v24_targeted_low_offbeat_pool`
+- source generated / selected: `4000 / 128`
+- source strict offbeat `<=0.390625` rows: `23`
+- source strict offbeat gate `0` rows: `0`
+- source judgment: 낮은 offbeat 후보 생성 확인, pre-repair resolution/unresolved/gate 미충족
+- best-of package: `manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe`
+- frontier role: outside-feel/offbeat reduction review expansion, representative replacement `false`
+- best-of candidate pool / selected: `1999 / 8`
+- max-per-case: `3`
+- pre-repair gate widened: max gate penalty `1.0000`, max unresolved offbeat non-chord `0.1000`
+- final strict offbeat cap: `0.390625`
+- final strict bar pitch-class similarity cap: `0.6750`
+- selected source duplicate sha/path: `0 / 0`
+- selected source note: 최종 top8은 v24 source package 직접 선택이 아니라 기존 parameter sweep 후보의 widened pre-repair gate 통과 후 repair/filter 결과
+- strong-beat chord-tone: `1.0000`
+- offbeat non-chord / resolution / unresolved: `0.3711 / 1.0000 / 0.0000`
+- max gate penalty / adjacent repeat: `0.0000 / 0.0000`
+- step motion / chromatic step / large leap: `0.4345 / 0.2401 / 0.0437`
+- enclosure proxy / bar pitch-class similarity: `0.3242 / 0.6429`
+- altered offbeat / interval trigram repeat: `0.1719 / 0.0082`
+- motion balance changed candidates / pitch repair steps: `8 / 36`
+- compared against motion-balance: offbeat `0.4063 -> 0.3711`, step motion `0.4226 -> 0.4345`, enclosure `0.3125 -> 0.3242`
+- recorded tradeoff against motion-balance: chromatic step `0.2440 -> 0.2401`, bar pitch-class similarity `0.6339 -> 0.6429`
+- preserved metrics against motion-balance: max gate penalty `0.0000`, adjacent repeat `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`, large leap `0.0437`
+- MIDI / solo WAV / context WAV: `8 / 8 / 8`
+- all-selected note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_dedup_all_selected_note_review/bebop_language_note_review.md`
+- package report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/bebop_language_best_of_package.md`
+- review handoff path: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_targeted_low_offbeat_review_handoff/bebop_language_review_handoff.md`
+- review ready: `true`
+- next boundary: `listening_review_input_or_motion_balance_guard_tightening`
 - representative replacement: `false`
 - quality claim: `false`
 - model direct claim: `false`


### PR DESCRIPTION
## Summary
- targeted-low-offbeat top8 best-of 결과를 README와 current status에 기록
- source attempt / best-of / note review / handoff 경로와 재현 명령 정리
- 낮은 offbeat source attempt와 최종 top8 선정 경로 분리 기록

## Context
- #1428 결과, 현 repaired pool 기준 offbeat cap 하향은 top8 유지 불가
- v24 low-offbeat source attempt: generated / selected `4000 / 128`
- source strict offbeat `<=0.390625` rows: `23`, strict offbeat gate `0` rows: `0`
- 최종 top8: v24 직접 선택이 아니라 기존 parameter sweep 후보의 widened pre-repair gate 통과 후 repair/filter 결과

## Result
- best-of candidate pool / selected: `1999 / 8`
- offbeat non-chord: `0.4063 -> 0.3711`
- resolution / unresolved / gate: `1.0000 / 0.0000 / 0.0000` 유지
- step motion: `0.4226 -> 0.4345`
- enclosure proxy: `0.3125 -> 0.3242`
- chromatic step: `0.2440 -> 0.2401`, bar similarity: `0.6339 -> 0.6429` tradeoff
- solo WAV / context WAV: `8 / 8`

## Scope
- README 최신 frontier/handoff/result path 갱신
- current status active issue/result/next boundary 갱신
- public artifact tool-neutral wording 유지

## Validation
- `git diff --check`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh demo`

## Risk
- musical quality claim 제외
- model-direct claim 제외
- human listening preference input 미반영
- next boundary: `listening_review_input_or_motion_balance_guard_tightening`

Closes #1430