### PR TITLE
Stage B bebop language targeted low-offbeat case balance repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 - 생성 방식: Music Transformer 계열 symbolic checkpoint + constrained decoding
 - 출력 단위: 2-8마디 solo-line MIDI 후보
 - 최신 대표 review package: strict-listen top4 stepwise-large-leap-guard, MIDI `4`, WAV `4`
-- 최신 frontier review package: strict-listen top8 targeted-low-offbeat, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
-- 최신 offbeat 개선: offbeat non-chord `0.4063 -> 0.3711`, resolution `1.0000`, unresolved `0.0000`
-- 최신 review handoff: targeted-low-offbeat, review ready `true`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`
+- 최신 frontier review package: strict-listen top8 targeted-low-offbeat case-balanced, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
+- 최신 case balance: selected case counts `3/3/1/1 -> 2/2/2/2`, offbeat non-chord `0.3711`, resolution `1.0000`, unresolved `0.0000`
+- 최신 review handoff: targeted-low-offbeat case-balanced, review ready `true`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`
 - 최신 guard feasibility: motion-balance guard/motion feasible config `20`, stricter offbeat feasible `false`, stricter bar similarity feasible `true`
 - 최신 pool expansion review package: strict-listen top8 safety-pool-expansion, representative replacement `false`
 - 최신 feasibility sweep: safety-gate motion/leap strict filter feasible config `0`
@@ -75,6 +75,7 @@
 - bebop language motion-balance review handoff: review ready `true`, selected `8`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`, baseline improved `4`, tradeoff watch `2`, unchanged guard `4`, quality claim `false`
 - bebop language motion-balance guard feasibility sweep: repaired pool `21`, safety baseline `19`, selectable max-per-case `2 / 3` = `8 / 11`, feasible guard/motion config `20`, min feasible offbeat max `0.40625`, min feasible bar similarity max `0.675`, stricter offbeat feasible `false`, stricter bar similarity feasible `true`, next `motion_balance_guard_tightening_candidate_package`
 - bebop language targeted-low-offbeat package: generated candidate pool `1999`, selected `8`, max gate penalty `0.0000`, offbeat non-chord `0.4063 -> 0.3711`, offbeat resolution `1.0000`, unresolved `0.0000`, step motion `0.4226 -> 0.4345`, chromatic step `0.2440 -> 0.2401`, large leap `0.0437 -> 0.0437`, enclosure proxy `0.3125 -> 0.3242`, bar pitch-class similarity `0.6339 -> 0.6429`, motion-balance changed candidates `8 / 8`, pitch repair steps `36`, quality claim `false`
+- bebop language targeted-low-offbeat case-balanced package: candidate pool `1999`, selected `8`, max-per-case `2`, selected case counts `3/3/1/1 -> 2/2/2/2`, offbeat non-chord `0.3711 -> 0.3711`, offbeat resolution `1.0000`, unresolved `0.0000`, max gate penalty `0.0000`, adjacent repeat `0.0000`, step motion `0.4345 -> 0.4325`, chromatic step `0.2401 -> 0.2321`, large leap `0.0437 -> 0.0456`, enclosure proxy `0.3242 -> 0.3164`, bar pitch-class similarity `0.6429 -> 0.6429`, quality claim `false`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -140,6 +141,10 @@
 - targeted-low-offbeat top8 package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/bebop_language_best_of_package.md`
 - targeted-low-offbeat top8 all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_dedup_all_selected_note_review/bebop_language_note_review.md`
 - targeted-low-offbeat review handoff: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_targeted_low_offbeat_review_handoff/bebop_language_review_handoff.md`
+- targeted-low-offbeat case-balanced top8 전체 context WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_case_balanced_probe/audio_with_context/`
+- targeted-low-offbeat case-balanced top8 package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_case_balanced_probe/bebop_language_best_of_package.md`
+- targeted-low-offbeat case-balanced top8 all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_case_balanced_all_selected_note_review/bebop_language_note_review.md`
+- targeted-low-offbeat case-balanced review handoff: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_targeted_low_offbeat_case_balanced_review_handoff/bebop_language_review_handoff.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -411,6 +416,65 @@
   --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/bebop_language_best_of_package.json \
   --baseline_package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_motion_balance_probe/bebop_language_best_of_package.json \
   --note_review outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_dedup_all_selected_note_review/bebop_language_note_review.json \
+  --expected_candidate_count 8
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py \
+  --run_id manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_case_balanced_probe \
+  --package_globs 'manual_2026_06_13_bebop_language_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json' \
+  --selected_count 8 \
+  --max_per_case 2 \
+  --bars 8 \
+  --bpm 124 \
+  --target_chord_tone_ratio 0.82 \
+  --target_offbeat_non_chord_ratio 0.34 \
+  --max_gate_penalty 1.0 \
+  --max_offbeat_non_chord_ratio 0.390625 \
+  --max_unresolved_offbeat_non_chord_ratio 0.10 \
+  --max_dominant_altered_offbeat_ratio 0.25 \
+  --max_adjacent_repeat_ratio 0 \
+  --max_bar_pitch_class_jaccard 0.675 \
+  --listen_first_mode consonance \
+  --repair_bar_similarity \
+  --repair_bar_similarity_iterations 4 \
+  --repair_enclosure_density \
+  --repair_enclosure_density_iterations 8 \
+  --repair_unresolved_offbeat \
+  --repair_unresolved_offbeat_iterations 8 \
+  --repair_adjacent_repeats \
+  --repair_adjacent_repeats_iterations 4 \
+  --repair_large_leaps \
+  --repair_large_leaps_iterations 8 \
+  --repair_motion_balance \
+  --repair_motion_balance_iterations 12 \
+  --target_min_step_motion_ratio 0.40 \
+  --target_min_chromatic_step_ratio 0.22 \
+  --target_max_large_leap_ratio 0.055 \
+  --max_motion_balance_bar_pitch_class_jaccard 0.675 \
+  --repair_rhythm_articulation \
+  --min_large_leap_repair_enclosure_proxy_ratio 0.28125 \
+  --max_enclosure_repair_offbeat_non_chord_ratio 0.421875 \
+  --context_bass_velocity_boost 6 \
+  --context_comp_velocity_boost 10 \
+  --select_after_repair \
+  --selection_profile bebop_stepwise_chromatic
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
+  --run_id manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_case_balanced_all_selected_note_review \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_case_balanced_probe/bebop_language_best_of_package.json \
+  --all_candidates \
+  --max_notes 32
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_review_handoff.py \
+  --run_id manual_2026_06_13_bebop_language_targeted_low_offbeat_case_balanced_review_handoff \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_case_balanced_probe/bebop_language_best_of_package.json \
+  --baseline_package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/bebop_language_best_of_package.json \
+  --note_review outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_case_balanced_all_selected_note_review/bebop_language_note_review.json \
   --expected_candidate_count 8
 ```
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,9 +22,9 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1430, Stage B MIDI-to-solo bebop language targeted offbeat pool expansion
+- current issue: Issue #1432, Stage B MIDI-to-solo bebop language targeted low-offbeat case balance repair
 - open issue queue after residual-aware listening input guard merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted-low-offbeat listening review or case-balance repair`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted-low-offbeat listening review input or motion-balance guard tightening`
 
 현재 범위가 아닌 것:
 
@@ -265,6 +265,37 @@
 - all-selected note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_dedup_all_selected_note_review/bebop_language_note_review.md`
 - package report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe/bebop_language_best_of_package.md`
 - review handoff path: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_targeted_low_offbeat_review_handoff/bebop_language_review_handoff.md`
+- review ready: `true`
+- next boundary: `listening_review_input_or_motion_balance_guard_tightening`
+- representative replacement: `false`
+- quality claim: `false`
+- model direct claim: `false`
+
+2026-06-13 targeted low-offbeat case-balanced package 기준:
+
+- package: `manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_case_balanced_probe`
+- baseline package: `manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_dedup_probe`
+- source pool unchanged: `true`
+- best-of candidate pool / selected: `1999 / 8`
+- max-per-case: `2`
+- selected case counts before: dominant_cycle `3`, rhythm_turnaround `3`, major_ii_v_turnaround `1`, minor_backdoor `1`
+- selected case counts after: dominant_cycle `2`, major_ii_v_turnaround `2`, minor_backdoor `2`, rhythm_turnaround `2`
+- final strict offbeat cap: `0.390625`
+- final strict bar pitch-class similarity cap: `0.6750`
+- strong-beat chord-tone: `1.0000`
+- offbeat non-chord / resolution / unresolved: `0.3711 / 1.0000 / 0.0000`
+- max gate penalty / adjacent repeat: `0.0000 / 0.0000`
+- step motion / chromatic step / large leap: `0.4325 / 0.2321 / 0.0456`
+- enclosure proxy / bar pitch-class similarity: `0.3164 / 0.6429`
+- altered offbeat / interval trigram repeat: `0.1719 / 0.0082`
+- motion balance pitch repair steps: `29`
+- compared against targeted-low-offbeat: case counts `3/3/1/1 -> 2/2/2/2`, offbeat `0.3711 -> 0.3711`, bar pitch-class similarity `0.6429 -> 0.6429`
+- recorded tradeoff against targeted-low-offbeat: step motion `0.4345 -> 0.4325`, chromatic step `0.2401 -> 0.2321`, large leap `0.0437 -> 0.0456`, enclosure `0.3242 -> 0.3164`
+- preserved metrics against targeted-low-offbeat: max gate penalty `0.0000`, adjacent repeat `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`
+- MIDI / solo WAV / context WAV: `8 / 8 / 8`
+- all-selected note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_targeted_low_offbeat_case_balanced_all_selected_note_review/bebop_language_note_review.md`
+- package report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_case_balanced_probe/bebop_language_best_of_package.md`
+- review handoff path: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_targeted_low_offbeat_case_balanced_review_handoff/bebop_language_review_handoff.md`
 - review ready: `true`
 - next boundary: `listening_review_input_or_motion_balance_guard_tightening`
 - representative replacement: `false`


### PR DESCRIPTION
## Summary
- targeted-low-offbeat top8의 case balance 개선 결과 기록
- same source pool 기준 `max_per_case=2` selection boundary 검증
- balanced top8 package / note review / handoff 경로와 재현 명령 정리

## Context
- #1430 targeted-low-offbeat top8 결과: selected `8`, offbeat non-chord `0.3711`
- 기존 selected case counts: dominant_cycle `3`, rhythm_turnaround `3`, major_ii_v_turnaround `1`, minor_backdoor `1`
- review coverage 관점에서 progression case 편중 존재

## Result
- best-of candidate pool / selected: `1999 / 8`
- max-per-case: `2`
- selected case counts: `3/3/1/1 -> 2/2/2/2`
- offbeat non-chord: `0.3711 -> 0.3711`
- resolution / unresolved / gate: `1.0000 / 0.0000 / 0.0000` 유지
- adjacent repeat: `0.0000` 유지
- step motion: `0.4345 -> 0.4325`
- chromatic step: `0.2401 -> 0.2321`
- large leap: `0.0437 -> 0.0456`
- enclosure proxy: `0.3242 -> 0.3164`
- solo WAV / context WAV: `8 / 8`

## Scope
- README latest frontier/handoff/result path 갱신
- current status active issue/result/next boundary 갱신
- same source pool 기준 selection boundary 변경 기록

## Validation
- case-balanced best-of package generation
- note review generation
- review handoff generation
- `git diff --check`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh demo`

## Risk
- musical quality claim 제외
- model-direct claim 제외
- objective metric 개선과 listening preference 분리
- motion 계열 지표 소폭 tradeoff 기록

Closes #1432