### PR TITLE
Stage B bebop language interval repeat guard audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 - 생성 방식: Music Transformer 계열 symbolic checkpoint + constrained decoding
 - 출력 단위: 2-8마디 solo-line MIDI 후보
 - 최신 대표 review package: strict-listen top4 stepwise-large-leap-guard, MIDI `4`, WAV `4`
-- 최신 frontier review package: strict-listen top8 case-balanced motion-tight, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
-- 최신 motion guard: selected case counts `2/2/2/2`, step `0.4325 -> 0.4583`, chromatic `0.2321 -> 0.2599`, large leap `0.0456 -> 0.0337`
-- 최신 review handoff: case-balanced motion-tight, review ready `true`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`
+- 최신 frontier review package: strict-listen top8 case-balanced motion interval-guard, MIDI `8`, solo/context WAV `8 / 8`, all-selected note review `8`
+- 최신 interval guard: cap `0.0125` selected `8` 불가, cap `0.0164` selected `8`, case counts `2/2/2/2`, interval repeat avg `0.0123`
+- 최신 review handoff: case-balanced motion interval-guard, review ready `true`, solo/context WAV `8 / 8`, listen-first audio pair `4`, note review validated `true`
 - 최신 guard feasibility: motion-balance guard/motion feasible config `20`, stricter offbeat feasible `false`, stricter bar similarity feasible `true`
 - 최신 pool expansion review package: strict-listen top8 safety-pool-expansion, representative replacement `false`
 - 최신 feasibility sweep: safety-gate motion/leap strict filter feasible config `0`
@@ -77,6 +77,7 @@
 - bebop language targeted-low-offbeat package: generated candidate pool `1999`, selected `8`, max gate penalty `0.0000`, offbeat non-chord `0.4063 -> 0.3711`, offbeat resolution `1.0000`, unresolved `0.0000`, step motion `0.4226 -> 0.4345`, chromatic step `0.2440 -> 0.2401`, large leap `0.0437 -> 0.0437`, enclosure proxy `0.3125 -> 0.3242`, bar pitch-class similarity `0.6339 -> 0.6429`, motion-balance changed candidates `8 / 8`, pitch repair steps `36`, quality claim `false`
 - bebop language targeted-low-offbeat case-balanced package: candidate pool `1999`, selected `8`, max-per-case `2`, selected case counts `3/3/1/1 -> 2/2/2/2`, offbeat non-chord `0.3711 -> 0.3711`, offbeat resolution `1.0000`, unresolved `0.0000`, max gate penalty `0.0000`, adjacent repeat `0.0000`, step motion `0.4345 -> 0.4325`, chromatic step `0.2401 -> 0.2321`, large leap `0.0437 -> 0.0456`, enclosure proxy `0.3242 -> 0.3164`, bar pitch-class similarity `0.6429 -> 0.6429`, quality claim `false`
 - bebop language case-balanced motion-tight package: candidate pool `1999`, selected `8`, selected case counts `2/2/2/2`, offbeat non-chord `0.3711 -> 0.3672`, offbeat resolution `1.0000`, unresolved `0.0000`, max gate penalty `0.0000`, adjacent repeat `0.0000`, step motion `0.4325 -> 0.4583`, chromatic step `0.2321 -> 0.2599`, large leap `0.0456 -> 0.0337`, enclosure proxy `0.3164 -> 0.3242`, bar pitch-class similarity `0.6429 -> 0.6345`, dominant altered offbeat `0.1719 -> 0.0703`, motion-balance pitch repair steps `60`, quality claim `false`
+- bebop language interval-repeat guard audit: strict cap `0.0125` failed with selected count shortage under max-per-case `2`, feasible cap `0.0164`, selected `8`, selected case counts `2/2/2/2`, interval trigram repeat avg `0.0123`, max selected interval trigram repeat `0.0164`, gate/resolution/unresolved/motion metrics preserved, quality claim `false`
 - bebop language best-of with-sweeps package: source package `91`, pool `1263`, selected `16`, score `0.2143`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4277`, offbeat resolution `0.9177`, unresolved offbeat non-chord `0.0352`, altered offbeat `0.1836`, two-note cycle `0.0082`, max gate penalty `0.0639`
 - bebop language best-of balanced package: source package `33`, pool `335`, selected `16`, score `0.2728`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4414`, offbeat resolution `0.8983`, unresolved offbeat non-chord `0.0449`, altered offbeat `0.1602`, two-note cycle `0.0092`, max-per-case `4`
 - bebop language altered-color balanced package: generated `4000`, selected `16`, strong-beat chord-tone `1.0000`, offbeat non-chord `0.4512`, offbeat resolution `0.8914`, unresolved offbeat non-chord `0.0488`, unique pitch avg `14.8125`, 3rd/4th motion `0.4831`, large leap `0.0863`, altered offbeat `0.1445`, bar pitch-class similarity `0.7027`, half-repeat `0.0000`
@@ -150,6 +151,10 @@
 - case-balanced motion-tight top8 package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_tight_probe/bebop_language_best_of_package.md`
 - case-balanced motion-tight top8 all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_case_balanced_motion_tight_all_selected_note_review/bebop_language_note_review.md`
 - case-balanced motion-tight review handoff: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_case_balanced_motion_tight_review_handoff/bebop_language_review_handoff.md`
+- case-balanced motion interval-guard top8 전체 context WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_interval_guard_feasible_probe/audio_with_context/`
+- case-balanced motion interval-guard top8 package report: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_interval_guard_feasible_probe/bebop_language_best_of_package.md`
+- case-balanced motion interval-guard top8 all-selected note review: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_case_balanced_motion_interval_guard_all_selected_note_review/bebop_language_note_review.md`
+- case-balanced motion interval-guard review handoff: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_case_balanced_motion_interval_guard_review_handoff/bebop_language_review_handoff.md`
 - altered-color balanced 대표 청취: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/listen_first_by_progression/`
 - altered-color balanced 전체 WAV: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/audio_with_context/`
 - altered-color balanced package report: `outputs/stage_b_midi_to_solo_bebop_language_package/manual_2026_06_13_bebop_language_v22_altered_color_balanced/bebop_language_package.md`
@@ -539,6 +544,66 @@
   --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_tight_probe/bebop_language_best_of_package.json \
   --baseline_package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_targeted_low_offbeat_case_balanced_probe/bebop_language_best_of_package.json \
   --note_review outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_case_balanced_motion_tight_all_selected_note_review/bebop_language_note_review.json \
+  --expected_candidate_count 8
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py \
+  --run_id manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_interval_guard_feasible_probe \
+  --package_globs 'manual_2026_06_13_bebop_language_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v6_data_contour_resolution/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v7_altered_balanced/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v8_v22_micro/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v9_strict_consonance/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v10_interval_repeat_rank/config_*/bebop_language_package.json,parameter_sweep/manual_2026_06_13_bebop_language_param_sweep_v11_large_leap_pool/config_*/bebop_language_package.json' \
+  --selected_count 8 \
+  --max_per_case 2 \
+  --bars 8 \
+  --bpm 124 \
+  --target_chord_tone_ratio 0.82 \
+  --target_offbeat_non_chord_ratio 0.34 \
+  --max_gate_penalty 1.0 \
+  --max_offbeat_non_chord_ratio 0.390625 \
+  --max_unresolved_offbeat_non_chord_ratio 0.10 \
+  --max_dominant_altered_offbeat_ratio 0.25 \
+  --max_adjacent_repeat_ratio 0 \
+  --max_interval_trigram_repeat_ratio 0.0164 \
+  --max_bar_pitch_class_jaccard 0.675 \
+  --listen_first_mode consonance \
+  --repair_bar_similarity \
+  --repair_bar_similarity_iterations 4 \
+  --repair_enclosure_density \
+  --repair_enclosure_density_iterations 8 \
+  --repair_unresolved_offbeat \
+  --repair_unresolved_offbeat_iterations 8 \
+  --repair_adjacent_repeats \
+  --repair_adjacent_repeats_iterations 4 \
+  --repair_large_leaps \
+  --repair_large_leaps_iterations 12 \
+  --repair_motion_balance \
+  --repair_motion_balance_iterations 24 \
+  --target_min_step_motion_ratio 0.43 \
+  --target_min_chromatic_step_ratio 0.24 \
+  --target_max_large_leap_ratio 0.045 \
+  --max_motion_balance_bar_pitch_class_jaccard 0.675 \
+  --repair_rhythm_articulation \
+  --min_large_leap_repair_enclosure_proxy_ratio 0.28125 \
+  --max_enclosure_repair_offbeat_non_chord_ratio 0.421875 \
+  --context_bass_velocity_boost 6 \
+  --context_comp_velocity_boost 10 \
+  --select_after_repair \
+  --selection_profile bebop_stepwise_chromatic
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_note_review.py \
+  --run_id manual_2026_06_13_bebop_language_top8_case_balanced_motion_interval_guard_all_selected_note_review \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_interval_guard_feasible_probe/bebop_language_best_of_package.json \
+  --all_candidates \
+  --max_notes 32
+```
+
+```bash
+.venv/bin/python scripts/build_stage_b_midi_to_solo_bebop_language_review_handoff.py \
+  --run_id manual_2026_06_13_bebop_language_case_balanced_motion_interval_guard_review_handoff \
+  --package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_interval_guard_feasible_probe/bebop_language_best_of_package.json \
+  --baseline_package outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_tight_probe/bebop_language_best_of_package.json \
+  --note_review outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_case_balanced_motion_interval_guard_all_selected_note_review/bebop_language_note_review.json \
   --expected_candidate_count 8
 ```
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,9 +22,9 @@
 - latest residual-aware listening review pending: Issue #1398, Stage B MIDI-to-solo residual-aware listening review pending boundary
 - latest residual-aware completion audit: Issue #1400, Stage B MIDI-to-solo residual-aware completion audit
 - latest residual-aware final status sync: Issue #1402, Stage B MIDI-to-solo residual-aware final status sync
-- current issue: Issue #1434, Stage B MIDI-to-solo bebop language case-balanced motion guard tightening
+- current issue: Issue #1436, Stage B MIDI-to-solo bebop language interval repeat guard audit
 - open issue queue after residual-aware listening input guard merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo case-balanced motion-tight listening review input or interval-repeat guard audit`
+- 다음 권장 이슈: `Stage B MIDI-to-solo interval-repeat source expansion or listening review input`
 
 현재 범위가 아닌 것:
 
@@ -330,6 +330,36 @@
 - review handoff path: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_case_balanced_motion_tight_review_handoff/bebop_language_review_handoff.md`
 - review ready: `true`
 - next boundary: `listening_review_input_or_motion_balance_guard_tightening`
+- representative replacement: `false`
+- quality claim: `false`
+- model direct claim: `false`
+
+2026-06-13 interval-repeat guard audit 기준:
+
+- package: `manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_interval_guard_feasible_probe`
+- baseline package: `manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_tight_probe`
+- source pool unchanged: `true`
+- new filter option: `--max_interval_trigram_repeat_ratio`
+- strict interval cap attempt: `0.0125`
+- strict interval cap result: selected count shortage under max-per-case `2`
+- feasible interval cap: `0.0164`
+- best-of candidate pool / selected: `1999 / 8`
+- max-per-case: `2`
+- selected case counts: dominant_cycle `2`, major_ii_v_turnaround `2`, minor_backdoor `2`, rhythm_turnaround `2`
+- selected interval trigram repeat values: `0.0164, 0.0164, 0.0164, 0.0000, 0.0000, 0.0164, 0.0164, 0.0164`
+- interval trigram repeat avg / max selected: `0.0123 / 0.0164`
+- offbeat non-chord / resolution / unresolved: `0.3672 / 1.0000 / 0.0000`
+- max gate penalty / adjacent repeat: `0.0000 / 0.0000`
+- step motion / chromatic step / large leap: `0.4583 / 0.2599 / 0.0337`
+- enclosure proxy / bar pitch-class similarity: `0.3242 / 0.6345`
+- compared against motion-tight baseline: objective metrics unchanged
+- preserved metrics against motion-tight baseline: selected case counts `2/2/2/2`, max gate penalty `0.0000`, adjacent repeat `0.0000`, offbeat resolution `1.0000`, unresolved `0.0000`
+- MIDI / solo WAV / context WAV: `8 / 8 / 8`
+- all-selected note review path: `outputs/stage_b_midi_to_solo_bebop_language_note_review/manual_2026_06_13_bebop_language_top8_case_balanced_motion_interval_guard_all_selected_note_review/bebop_language_note_review.md`
+- package report path: `outputs/stage_b_midi_to_solo_bebop_language_package/best_of/manual_2026_06_13_bebop_language_best_of_top8_case_balanced_motion_interval_guard_feasible_probe/bebop_language_best_of_package.md`
+- review handoff path: `outputs/stage_b_midi_to_solo_bebop_language_review_handoff/manual_2026_06_13_bebop_language_case_balanced_motion_interval_guard_review_handoff/bebop_language_review_handoff.md`
+- review ready: `true`
+- next boundary: `interval_repeat_source_expansion_or_listening_review_input`
 - representative replacement: `false`
 - quality claim: `false`
 - model direct claim: `false`

--- a/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
+++ b/scripts/build_stage_b_midi_to_solo_bebop_language_best_of_package.py
@@ -126,7 +126,8 @@ def filter_candidate_rows(
     max_unresolved_offbeat_non_chord_ratio: float | None,
     max_dominant_altered_offbeat_ratio: float | None,
     max_adjacent_repeat_ratio: float | None,
-    max_bar_pitch_class_jaccard: float | None,
+    max_interval_trigram_repeat_ratio: float | None = None,
+    max_bar_pitch_class_jaccard: float | None = None,
 ) -> list[dict[str, Any]]:
     filtered: list[dict[str, Any]] = []
     for row in rows:
@@ -151,6 +152,11 @@ def filter_candidate_rows(
         if (
             max_adjacent_repeat_ratio is not None
             and float(metrics["adjacent_repeat_ratio"]) > float(max_adjacent_repeat_ratio)
+        ):
+            continue
+        if (
+            max_interval_trigram_repeat_ratio is not None
+            and float(metrics["interval_trigram_repeat_ratio"]) > float(max_interval_trigram_repeat_ratio)
         ):
             continue
         if (
@@ -1570,6 +1576,7 @@ def build_best_of_package(
     max_unresolved_offbeat_non_chord_ratio: float | None = None,
     max_dominant_altered_offbeat_ratio: float | None = None,
     max_adjacent_repeat_ratio: float | None = None,
+    max_interval_trigram_repeat_ratio: float | None = None,
     max_bar_pitch_class_jaccard: float | None = None,
     listen_first_mode: str = "rank",
     repair_bar_similarity_enabled: bool = False,
@@ -1609,6 +1616,7 @@ def build_best_of_package(
         max_unresolved_offbeat_non_chord_ratio=max_unresolved_offbeat_non_chord_ratio,
         max_dominant_altered_offbeat_ratio=max_dominant_altered_offbeat_ratio,
         max_adjacent_repeat_ratio=None if select_after_repair else max_adjacent_repeat_ratio,
+        max_interval_trigram_repeat_ratio=None if select_after_repair else max_interval_trigram_repeat_ratio,
         max_bar_pitch_class_jaccard=None if select_after_repair else max_bar_pitch_class_jaccard,
     )
     if not selection_rows:
@@ -1676,6 +1684,7 @@ def build_best_of_package(
                 max_unresolved_offbeat_non_chord_ratio=max_unresolved_offbeat_non_chord_ratio,
                 max_dominant_altered_offbeat_ratio=max_dominant_altered_offbeat_ratio,
                 max_adjacent_repeat_ratio=max_adjacent_repeat_ratio,
+                max_interval_trigram_repeat_ratio=max_interval_trigram_repeat_ratio,
                 max_bar_pitch_class_jaccard=max_bar_pitch_class_jaccard,
             ),
             key=lambda row: selection_sort_key(row, selection_profile=selection_profile),
@@ -1854,6 +1863,7 @@ def build_best_of_package(
             "max_unresolved_offbeat_non_chord_ratio": max_unresolved_offbeat_non_chord_ratio,
             "max_dominant_altered_offbeat_ratio": max_dominant_altered_offbeat_ratio,
             "max_adjacent_repeat_ratio": max_adjacent_repeat_ratio,
+            "max_interval_trigram_repeat_ratio": max_interval_trigram_repeat_ratio,
             "max_bar_pitch_class_jaccard": max_bar_pitch_class_jaccard,
             "listen_first_mode": listen_first_mode,
             "repair_bar_similarity": bool(repair_bar_similarity_enabled),
@@ -1924,6 +1934,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max_unresolved_offbeat_non_chord_ratio", type=float, default=None)
     parser.add_argument("--max_dominant_altered_offbeat_ratio", type=float, default=None)
     parser.add_argument("--max_adjacent_repeat_ratio", type=float, default=None)
+    parser.add_argument("--max_interval_trigram_repeat_ratio", type=float, default=None)
     parser.add_argument("--max_bar_pitch_class_jaccard", type=float, default=None)
     parser.add_argument("--listen_first_mode", choices=["rank", "consonance"], default="rank")
     parser.add_argument("--repair_bar_similarity", action="store_true")
@@ -1983,6 +1994,7 @@ def main() -> int:
         max_unresolved_offbeat_non_chord_ratio=args.max_unresolved_offbeat_non_chord_ratio,
         max_dominant_altered_offbeat_ratio=args.max_dominant_altered_offbeat_ratio,
         max_adjacent_repeat_ratio=args.max_adjacent_repeat_ratio,
+        max_interval_trigram_repeat_ratio=args.max_interval_trigram_repeat_ratio,
         max_bar_pitch_class_jaccard=args.max_bar_pitch_class_jaccard,
         listen_first_mode=str(args.listen_first_mode),
         repair_bar_similarity_enabled=bool(args.repair_bar_similarity),

--- a/tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py
+++ b/tests/test_stage_b_midi_to_solo_bebop_language_rhythm_articulation.py
@@ -133,6 +133,40 @@ class BebopLanguageRhythmArticulationTest(unittest.TestCase):
 
         self.assertEqual(filtered, [safe])
 
+    def test_safety_filter_excludes_interval_trigram_repeat_regression(self) -> None:
+        base_metrics = {
+            "offbeat_non_chord_ratio": 0.390625,
+            "offbeat_unresolved_non_chord_ratio": 0.0,
+            "dominant_altered_offbeat_ratio": 0.125,
+            "adjacent_repeat_ratio": 0.0,
+            "interval_trigram_repeat_ratio": 0.0082,
+            "max_bar_pitch_class_jaccard": 0.62,
+        }
+        safe = {
+            "gate_penalty": 0.0,
+            "objective_metrics": base_metrics,
+        }
+        interval_repeat_regression = {
+            "gate_penalty": 0.0,
+            "objective_metrics": {
+                **base_metrics,
+                "interval_trigram_repeat_ratio": 0.0164,
+            },
+        }
+
+        filtered = filter_candidate_rows(
+            [safe, interval_repeat_regression],
+            max_gate_penalty=0.0,
+            max_offbeat_non_chord_ratio=0.40625,
+            max_unresolved_offbeat_non_chord_ratio=0.0,
+            max_dominant_altered_offbeat_ratio=0.25,
+            max_adjacent_repeat_ratio=0.0,
+            max_interval_trigram_repeat_ratio=0.0125,
+            max_bar_pitch_class_jaccard=0.625,
+        )
+
+        self.assertEqual(filtered, [safe])
+
     def test_motion_balance_score_prefers_stepwise_chromatic_lower_leap_candidate(self) -> None:
         base_metrics = {
             "step_motion_ratio": 0.34,


### PR DESCRIPTION
## Summary
- best-of selection에 interval trigram repeat hard cap 추가
- case-balanced motion-tight top8 기준 interval-repeat guard feasibility 기록
- feasible cap package / note review / handoff 경로와 재현 명령 정리

## Context
- #1434 motion-tight top8 결과 selected `8`, case counts `2/2/2/2`
- step `0.4325 -> 0.4583`, chromatic `0.2321 -> 0.2599`, large leap `0.0456 -> 0.0337` 개선
- interval trigram repeat `0.0082 -> 0.0123` 증가
- 기존 hard filter: adjacent repeat cap 존재, interval trigram repeat cap 없음

## Changes
- `--max_interval_trigram_repeat_ratio` CLI option 추가
- pre-repair / repaired-selection filter에 interval trigram repeat cap 적용
- generation metadata에 interval cap 기록
- interval repeat 초과 후보 제외 테스트 추가

## Result
- strict cap `0.0125`: max-per-case `2` 조건에서 selected `8` 부족
- feasible cap `0.0164`: selected `8`
- selected case counts: `2/2/2/2` 유지
- interval trigram repeat avg / max selected: `0.0123 / 0.0164`
- offbeat non-chord / resolution / unresolved: `0.3672 / 1.0000 / 0.0000` 유지
- gate / adjacent repeat: `0.0000 / 0.0000` 유지
- step / chromatic / large leap: `0.4583 / 0.2599 / 0.0337` 유지
- solo WAV / context WAV: `8 / 8`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_bebop_language_rhythm_articulation`
- interval-guarded best-of package generation
- note review generation
- review handoff generation
- `git diff --check`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh demo`

## Risk
- musical quality claim 제외
- model-direct claim 제외
- strict interval cap `0.0125`는 현재 source pool에서 top8 유지 불가
- next boundary: interval-repeat source expansion or listening review input

Closes #1436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interval trigram repeat ratio filtering constraint to candidate selection pipeline.

* **Documentation**
  * Updated status documentation with audit results and feasibility metrics.
  * Extended README with new artifact paths and reproduction commands.

* **Tests**
  * Added regression test for interval trigram repeat ratio filtering validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->