### PR TITLE
feat: enable local MPS training + add diversity metrics for style-FT diagnosis

### DIFF
--- a/MPS_TRAINING_GUIDE.md
+++ b/MPS_TRAINING_GUIDE.md
@@ -1,0 +1,127 @@
+# 로컬 MPS 학습 가이드 (Apple Silicon)
+
+당신 맥(arm64, macOS 26.4)의 GPU(Metal/MPS)로 Music Transformer를 학습하는 방법.
+어시스턴트 샌드박스에서는 MPS가 가려져 보이지 않으므로, **아래 명령은 당신이
+맥 터미널에서 직접** 실행합니다. 코드 경로는 어시스턴트가 CPU로 검증 완료.
+
+---
+
+## 0. 무엇이 바뀌었나 (이번에 수정한 것)
+
+| 파일 | 변경 |
+|---|---|
+| `music_transformer/utilities/device.py` | **MPS 지원 추가.** `get_device()` 우선순위: CUDA → MPS → CPU. `mps_device()` 추가. `FORCE_CPU=1` 환경변수로 MPS 끄기 가능. CUDA 경로는 그대로(하위호환). |
+| `archive/scripts/train_qlora.py` | **`--device {auto,cuda,mps,cpu}` 인자 추가.** 선택한 device를 모델 내부 `get_device()`와 자동 일치시킴(중요: forward의 causal mask가 내부에서 `get_device()`를 부름). 또 스크립트 이동으로 깨져 있던 import 경로(레포 루트 탐색, `checkpoint_utils`) 수정. |
+| `scripts/mps_smoke_test.py` | **신규.** MPS에서 forward+backward+step이 되는지 검증하고 CPU 대비 속도 비교. |
+
+`rpr.py`(커스텀 상대위치 어텐션)는 device-agnostic하게 작성돼 있어 MPS 호환
+가능성이 높습니다. 단 **확실한 검증은 아래 1단계 스모크 테스트로** 하세요.
+
+---
+
+## 1. 먼저: MPS 호환성 스모크 테스트 (필수, 30초)
+
+```bash
+cd /Users/ohhalim/git_box/fine_tuning_art-tatum_midi_solo
+./.venv/bin/python scripts/mps_smoke_test.py
+```
+
+**해석:**
+- `VERDICT: MPS is COMPATIBLE for rpr=True` → MPS에서 크래시 없이 학습 가능. **호환성 통과.**
+- `at least one op is not MPS-compatible` → 그 op이 MPS 미지원. 두 선택지:
+  - (a) 그냥 CPU로 학습 (`--device cpu`) — 13.4M 모델이라 probe/소규모는 CPU도 견딜 만함.
+  - (b) 폴백 켜고 재시도:
+    ```bash
+    PYTORCH_ENABLE_MPS_FALLBACK=1 ./.venv/bin/python scripts/mps_smoke_test.py
+    ```
+    미지원 op만 CPU로 떨어뜨림(느리지만 동작). 학습도 같은 env로 실행.
+
+### ⚠️ 중요: MPS가 항상 빠른 건 아님 (속도 크로스오버)
+
+실측 결과(2026-07, 당신 맥): **작은 shape에서는 CPU가 MPS보다 빠릅니다.**
+
+| shape | MPS | CPU | 승자 |
+|---|---|---|---|
+| batch 2, seq 256 (스모크) | 1.23s | 0.48s | **CPU ~2.5배** |
+
+이유: 13.4M은 작은 모델이라 GPU 커널 실행 오버헤드 + CPU↔GPU 전송 비용이
+실제 연산량보다 큽니다. 배치·시퀀스가 커지면(batch×seq²) MPS가 이기기 시작합니다.
+
+**그래서 device는 실험 규모별로 실측해서 정하세요:**
+```bash
+./.venv/bin/python scripts/mps_smoke_test.py --scale
+```
+이 명령이 batch/seq를 키워가며 MPS vs CPU steps/sec을 재고 각 shape의 승자를
+출력합니다. **그 표에서 당신 학습 shape의 승자를 골라 `--device`에 쓰세요.**
+
+- **D0-(a) 16조각 probe → `--device cpu`** (데이터 작아 CPU가 빠름)
+- **D0-(b) 전체 코퍼스 (batch 8, seq 512) → `--scale` 결과 보고 결정**
+
+---
+
+## 2. 실험 D0-(a): 16조각 probe 재현 (baseline)
+
+현재 상태를 그대로 재현해 baseline perplexity/loss를 확보합니다.
+
+```bash
+./.venv/bin/python archive/scripts/train_qlora.py \
+  --data_dir ./data/roles/lead/tokenized \
+  --output_dir ./checkpoints/d0a_probe_repro \
+  --device cpu \
+  --epochs 20 --batch_size 4 --max_sequence 512 \
+  --gradient_accumulation 1 --num_workers 0 \
+  --train_full_model
+```
+> probe는 16조각뿐이라 CPU가 MPS보다 빠릅니다(위 크로스오버 참고). `--device cpu` 사용.
+
+- `--train_full_model`: from-scratch full 학습(랜덤 base + LoRA-only 아님 — 그건 안 배웠던 실패 모드).
+- probe가 16조각뿐이라 몇 epoch 안에 train loss가 급락하면 **과적합**입니다 — 그게 정상이고, 요점은 "파이프라인이 학습 신호를 만드는가" 확인.
+- 어시스턴트 CPU 검증값(1 epoch): Train 5.74 / Val 5.42 → 시작점 참고.
+
+## 3. 실험 D0-(b): 전체 코퍼스 투입 (핵심 대조)
+
+2,703개 non-Brad 코퍼스를 학습 포맷으로 토크나이즈한 뒤 동일 아키텍처로 학습.
+이게 "데이터 부족 vs base 한계"를 가르는 실험입니다.
+
+```bash
+# 1) 전체 코퍼스 토크나이즈 (CPU 작업, GPU 무관)
+./.venv/bin/python scripts/build_jazz_training_manifests.py   # 매니페스트 생성
+#    (실제 토크나이즈 스크립트/인자는 레포 파이프라인에 맞춰 어시스턴트와 확정)
+
+# 2) 학습 (MPS)
+./.venv/bin/python archive/scripts/train_qlora.py \
+  --data_dir ./data/jazz_processed \
+  --output_dir ./checkpoints/d0b_full_corpus \
+  --device mps \
+  --epochs 5 --batch_size 8 --max_sequence 512 \
+  --gradient_accumulation 4 --num_workers 0 \
+  --train_full_model
+```
+
+> 전체 코퍼스 학습은 MPS로도 수십 분~수 시간 걸릴 수 있습니다. 오래 걸리면
+> 이 잡만 RunPod으로 옮기는 게 합리적(어시스턴트가 스크립트 그대로 던짐).
+
+---
+
+## 4. 문제 해결
+
+| 증상 | 원인 / 조치 |
+|---|---|
+| `--device mps requested but MPS is not available` | macOS 14+ / Apple Silicon / MPS torch 빌드 확인. 1단계 스모크로 진단. |
+| `RuntimeError: ... not implemented for 'MPS'` | 그 op 미지원. `PYTORCH_ENABLE_MPS_FALLBACK=1` 붙여 재실행하거나 `--device cpu`. |
+| device mismatch (`cpu` vs `mps`) 에러 | 이번 패치로 해결됨(모델 내부 `get_device()`와 학습 device를 일치시킴). 재발 시 어시스턴트에 알릴 것. |
+| loss가 `nan` | lr 낮추기(`--lr 1e-4`), 또는 MPS의 fp 정밀도 이슈면 `--device cpu`로 교차확인. |
+| 느림 | batch_size↑(메모리 허용선까지), max_sequence를 512로 유지, num_workers는 MPS에서 0 권장. |
+
+---
+
+## 5. 다양성 지표 (다음 단계)
+
+loss/perplexity만으로는 "보이싱 다양성 붕괴"를 못 잡습니다. 학습 후 생성 샘플에
+대해 아래를 재는 스크립트를 어시스턴트가 추가 예정:
+- 고유 pitch-class-set(보이싱) 수 / 엔트로피
+- 화성 진행 n-gram 반복률
+- note density 분포
+
+이 지표로 D0-(a) vs (b)를 비교하면 "데이터를 더 넣으면 다양성이 회복되는가"에
+정량 답이 나옵니다.

--- a/music_transformer/utilities/device.py
+++ b/music_transformer/utilities/device.py
@@ -1,6 +1,7 @@
 # For all things related to devices
 #### ONLY USE PROVIDED FUNCTIONS, DO NOT USE GLOBAL CONSTANTS ####
 
+import os
 import torch
 
 TORCH_CPU_DEVICE = torch.device("cpu")
@@ -8,9 +9,25 @@ TORCH_CPU_DEVICE = torch.device("cpu")
 if(torch.cuda.device_count() > 0):
     TORCH_CUDA_DEVICE = torch.device("cuda")
 else:
-    print("----- WARNING: CUDA devices not detected. This will cause the model to run very slow! -----")
-    print("")
     TORCH_CUDA_DEVICE = None
+
+# Apple Silicon GPU (Metal / MPS). Detected once at import.
+# Disable explicitly with env FORCE_CPU=1 (useful for debugging).
+def _detect_mps():
+    if os.environ.get("FORCE_CPU", "") == "1":
+        return None
+    try:
+        if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+            return torch.device("mps")
+    except Exception:
+        pass
+    return None
+
+TORCH_MPS_DEVICE = _detect_mps()
+
+if(TORCH_CUDA_DEVICE is None and TORCH_MPS_DEVICE is None):
+    print("----- WARNING: no CUDA or MPS device detected. Training will run on CPU (slow). -----")
+    print("")
 
 USE_CUDA = True
 
@@ -20,7 +37,8 @@ def use_cuda(cuda_bool):
     ----------
     Author: Damon Gwinn
     ----------
-    Sets whether to use CUDA (if available), or use the CPU (not recommended)
+    Sets whether to use the GPU (CUDA or MPS, if available), or force the CPU.
+    Passing False forces CPU regardless of available accelerators.
     ----------
     """
 
@@ -31,16 +49,27 @@ def use_cuda(cuda_bool):
 def get_device():
     """
     ----------
-    Author: Damon Gwinn
+    Author: Damon Gwinn (MPS support added)
     ----------
-    Grabs the default device. Default device is CUDA if available and use_cuda is not False, CPU otherwise.
+    Grabs the default device. Preference order when use_cuda is not False:
+    CUDA -> MPS (Apple Silicon) -> CPU. Passing use_cuda(False) forces CPU.
+    Set env FORCE_CPU=1 to disable MPS detection at import time.
     ----------
     """
 
-    if((not USE_CUDA) or (TORCH_CUDA_DEVICE is None)):
+    if(not USE_CUDA):
         return TORCH_CPU_DEVICE
-    else:
+    if(TORCH_CUDA_DEVICE is not None):
         return TORCH_CUDA_DEVICE
+    if(TORCH_MPS_DEVICE is not None):
+        return TORCH_MPS_DEVICE
+    return TORCH_CPU_DEVICE
+
+# mps_device
+def mps_device():
+    """Grabs the MPS (Apple Silicon GPU) device, or None if unavailable."""
+
+    return TORCH_MPS_DEVICE
 
 # cuda_device
 def cuda_device():

--- a/scripts/diversity_metrics.py
+++ b/scripts/diversity_metrics.py
@@ -1,0 +1,305 @@
+"""
+Diversity metrics for Music-Transformer symbolic output.
+
+WHY: cross-entropy / perplexity cannot detect the failure modes you observed
+("voicing-diversity collapse", "harmonic-progression repetition", "long-range
+structure breakdown"). A model can lower loss while producing a narrower, more
+repetitive distribution of music. These metrics measure that distribution
+directly, so D0-(a) 16-file probe vs D0-(b) full-corpus can be compared on the
+axis that actually matters.
+
+WORKS ON: legacy Music-Transformer ("performance") tokenization — the scheme
+your training shards actually use (verified: tokens in 0..388).
+  note_on   0..127     pitch onset
+  note_off  128..255   pitch = token-128
+  time_shift 256..355  time += (token-256+1)/100 sec   (10ms .. 1000ms/step)
+  velocity  356..387   vel = (token-356)*4
+
+USAGE
+  # a directory of .npy token shards (training data or decoded generations)
+  ./.venv/bin/python scripts/diversity_metrics.py --npy_dir data/roles/lead/tokenized/train
+
+  # compare two sets side by side (e.g. probe vs full corpus, or data vs samples)
+  ./.venv/bin/python scripts/diversity_metrics.py \
+      --npy_dir data/roles/lead/tokenized/train \
+      --compare_dir data/jazz_processed/train \
+      --labels probe full --json_out outputs/diversity_probe_vs_full.json
+
+  # a single sample as a python API
+  from scripts.diversity_metrics import metrics_for_tokens
+  m = metrics_for_tokens(np.load("sample.npy"))
+
+Each metric is a scalar (or short vector) per sequence; the CLI reports the
+mean/std across sequences in a set, plus corpus-level pooled metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import Counter
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+# ---- authoritative token layout (from third_party/midi_processor/processor.py)
+NOTE_ON_START, NOTE_ON_END = 0, 127
+NOTE_OFF_START, NOTE_OFF_END = 128, 255
+TIME_SHIFT_START, TIME_SHIFT_END = 256, 355
+VELOCITY_START, VELOCITY_END = 356, 387
+TIME_STEP_SEC = 0.01  # each time-shift step = (value+1)/100 s
+
+
+# =============================================================================
+# Decode: token stream -> note events
+# =============================================================================
+def decode_notes(tokens: Sequence[int]):
+    """Return list of (onset_sec, pitch, duration_sec, velocity).
+
+    Mirrors the processor's event semantics: a NOTE_ON opens a note at the
+    current timeline; the matching NOTE_OFF closes it. Unmatched ONs are closed
+    at end-of-sequence. TIME_SHIFT advances the timeline.
+    """
+    t = 0.0
+    vel = 0
+    open_notes = {}  # pitch -> (onset, velocity)
+    notes = []
+    for tok in tokens:
+        tok = int(tok)
+        if NOTE_ON_START <= tok <= NOTE_ON_END:
+            pitch = tok - NOTE_ON_START
+            open_notes[pitch] = (t, vel)
+        elif NOTE_OFF_START <= tok <= NOTE_OFF_END:
+            pitch = tok - NOTE_OFF_START
+            if pitch in open_notes:
+                onset, v = open_notes.pop(pitch)
+                notes.append((onset, pitch, max(t - onset, 0.0), v))
+        elif TIME_SHIFT_START <= tok <= TIME_SHIFT_END:
+            t += (tok - TIME_SHIFT_START + 1) * TIME_STEP_SEC
+        elif VELOCITY_START <= tok <= VELOCITY_END:
+            vel = (tok - VELOCITY_START) * 4
+        # control/pad tokens (>=389) and anything else: ignored
+    for pitch, (onset, v) in open_notes.items():
+        notes.append((onset, pitch, 0.0, v))
+    notes.sort(key=lambda n: (n[0], n[1]))
+    return notes
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+def _entropy(counts) -> float:
+    """Shannon entropy (bits) of a Counter / iterable of counts."""
+    vals = np.asarray(list(counts.values()) if isinstance(counts, dict) else list(counts), float)
+    tot = vals.sum()
+    if tot <= 0:
+        return 0.0
+    p = vals[vals > 0] / tot
+    return float(-(p * np.log2(p)).sum())
+
+
+def group_voicings(notes, window_sec: float = 0.05):
+    """Group near-simultaneous note onsets into chords (pitch-class sets).
+
+    Returns list of frozenset(pitch_class). A window of 50 ms clusters notes a
+    human hears as one voicing (rolled chords included).
+    """
+    if not notes:
+        return []
+    onsets = np.array([n[0] for n in notes])
+    order = np.argsort(onsets)
+    voicings = []
+    cur_pcs, cur_t0 = set(), None
+    for i in order:
+        onset, pitch = notes[i][0], notes[i][1]
+        if cur_t0 is None or onset - cur_t0 <= window_sec:
+            if cur_t0 is None:
+                cur_t0 = onset
+            cur_pcs.add(pitch % 12)
+        else:
+            voicings.append(frozenset(cur_pcs))
+            cur_pcs, cur_t0 = {pitch % 12}, onset
+    if cur_pcs:
+        voicings.append(frozenset(cur_pcs))
+    return voicings
+
+
+def ngram_repetition(seq, n: int = 4) -> float:
+    """Fraction of n-grams that are repeats (1 - unique/total). 0 = all unique."""
+    if len(seq) < n:
+        return 0.0
+    grams = [tuple(seq[i:i + n]) for i in range(len(seq) - n + 1)]
+    return 1.0 - len(set(grams)) / len(grams)
+
+
+# =============================================================================
+# Per-sequence metrics
+# =============================================================================
+def notes_from_midi(path):
+    """Read a .mid/.midi into the same (onset, pitch, dur, vel) note list.
+
+    Uses pretty_midi directly (not a token round-trip) so metrics on generated
+    MIDI are independent of encode/decode quantization.
+    """
+    import pretty_midi
+    pm = pretty_midi.PrettyMIDI(str(path))
+    notes = []
+    for inst in pm.instruments:
+        if inst.is_drum:
+            continue
+        for n in inst.notes:
+            notes.append((float(n.start), int(n.pitch), float(n.end - n.start), int(n.velocity)))
+    notes.sort(key=lambda n: (n[0], n[1]))
+    return notes
+
+
+def metrics_for_midi(path) -> dict:
+    return _metrics_from_notes(notes_from_midi(path), token_seq=None)
+
+
+def metrics_for_tokens(tokens) -> dict:
+    tokens = np.asarray(tokens).ravel()
+    return _metrics_from_notes(decode_notes(tokens), token_seq=tokens)
+
+
+def _metrics_from_notes(notes, token_seq=None) -> dict:
+    n_notes = len(notes)
+
+    pitches = [p for _, p, _, _ in notes]
+    pcs = [p % 12 for p in pitches]
+    voicings = group_voicings(notes)
+    voicing_sizes = [len(v) for v in voicings]
+    span = (notes[-1][0] - notes[0][0]) if n_notes > 1 else 0.0
+
+    # inter-onset intervals (rhythm)
+    onsets = sorted(n[0] for n in notes)
+    iois = np.diff(onsets) if len(onsets) > 1 else np.array([])
+
+    return {
+        "n_notes": n_notes,
+        "n_voicings": len(voicings),
+        "duration_sec": round(span, 2),
+        "note_density_per_sec": round(n_notes / span, 3) if span > 0 else 0.0,
+        # --- pitch / harmony diversity ---
+        "pitch_class_entropy_bits": round(_entropy(Counter(pcs)), 3),   # max 3.585 (=log2 12)
+        "pitch_range_semitones": (max(pitches) - min(pitches)) if pitches else 0,
+        "unique_voicings": len(set(voicings)),
+        "voicing_entropy_bits": round(_entropy(Counter(voicings)), 3),
+        "distinct_voicing_ratio": round(len(set(voicings)) / len(voicings), 3) if voicings else 0.0,
+        "mean_voicing_size": round(float(np.mean(voicing_sizes)), 3) if voicing_sizes else 0.0,
+        # --- repetition (progression / motif) ---
+        "voicing_4gram_repeat": round(ngram_repetition(voicings, 4), 3),
+        "pitch_4gram_repeat": round(ngram_repetition(pitches, 4), 3),
+        "token_8gram_repeat": round(ngram_repetition(token_seq.tolist(), 8), 3) if token_seq is not None else -1.0,
+        # --- rhythm ---
+        "ioi_cv": round(float(np.std(iois) / np.mean(iois)), 3) if iois.size and np.mean(iois) > 0 else 0.0,
+    }
+
+
+# =============================================================================
+# Set-level aggregation
+# =============================================================================
+def _load_dir(d: Path):
+    """Load a set as list of (name, notes, token_seq|None).
+
+    Accepts .npy token shards (token_seq preserved) OR .mid/.midi (token_seq None).
+    """
+    npy = sorted(d.glob("*.npy"))
+    mids = sorted(list(d.glob("*.mid")) + list(d.glob("*.midi")))
+    if npy:
+        out = []
+        for f in npy:
+            toks = np.load(f).ravel()
+            out.append((f.name, decode_notes(toks), toks))
+        return out
+    if mids:
+        return [(f.name, notes_from_midi(f), None) for f in mids]
+    return []
+
+
+def summarize_set(data_dir: Path) -> dict:
+    items = _load_dir(data_dir)
+    if not items:
+        raise SystemExit(f"No .npy or .mid files in {data_dir}")
+    per_seq = [_metrics_from_notes(notes, token_seq=toks) for _, notes, toks in items]
+
+    keys = [k for k in per_seq[0] if isinstance(per_seq[0][k], (int, float))]
+    agg = {}
+    for k in keys:
+        vals = np.array([m[k] for m in per_seq], float)
+        vals = vals[vals >= 0]  # drop sentinel -1 (token metric absent for MIDI)
+        if vals.size == 0:
+            continue
+        agg[k] = {"mean": round(float(vals.mean()), 3), "std": round(float(vals.std()), 3)}
+
+    # corpus-level pooled diversity: unique voicings across the WHOLE set
+    all_voicings = []
+    for _, notes, _toks in items:
+        all_voicings.extend(group_voicings(notes))
+    pooled = {
+        "n_sequences": len(items),
+        "pooled_unique_voicings": len(set(all_voicings)),
+        "pooled_total_voicings": len(all_voicings),
+        "pooled_voicing_entropy_bits": round(_entropy(Counter(all_voicings)), 3),
+        "pooled_distinct_voicing_ratio": round(len(set(all_voicings)) / len(all_voicings), 3) if all_voicings else 0.0,
+    }
+    return {"per_sequence_mean_std": agg, "pooled": pooled}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Diversity metrics for symbolic music tokens")
+    ap.add_argument("--npy_dir", required=True, help="Directory of .npy token shards")
+    ap.add_argument("--compare_dir", default=None, help="Second set to compare against")
+    ap.add_argument("--labels", nargs=2, default=["A", "B"], help="Labels for the two sets")
+    ap.add_argument("--json_out", default=None, help="Write full results to this JSON path")
+    args = ap.parse_args()
+
+    results = {args.labels[0]: summarize_set(Path(args.npy_dir))}
+    if args.compare_dir:
+        results[args.labels[1]] = summarize_set(Path(args.compare_dir))
+
+    # console: the diversity-critical rows
+    keyrows = [
+        ("pitch_class_entropy_bits", "PC entropy (max 3.58)"),
+        ("voicing_entropy_bits", "voicing entropy"),
+        ("distinct_voicing_ratio", "distinct-voicing ratio"),
+        ("voicing_4gram_repeat", "voicing 4gram repeat (lower=better)"),
+        ("token_8gram_repeat", "token 8gram repeat (lower=better)"),
+        ("note_density_per_sec", "note density /s"),
+    ]
+    labels = list(results.keys())
+    print("\n" + "=" * 72)
+    print(f"{'metric':<38}" + "".join(f"{l:>16}" for l in labels))
+    print("-" * 72)
+    for k, desc in keyrows:
+        row = f"{desc:<38}"
+        for l in labels:
+            m = results[l]["per_sequence_mean_std"].get(k)
+            if m is None:
+                row += f"{'n/a':>16}"
+            else:
+                row += f"{m['mean']:>10.3f}±{m['std']:<5.3f}"
+        print(row)
+    print("-" * 72)
+    prow = f"{'pooled unique voicings':<38}"
+    erow = f"{'pooled voicing entropy':<38}"
+    for l in labels:
+        prow += f"{results[l]['pooled']['pooled_unique_voicings']:>16}"
+        erow += f"{results[l]['pooled']['pooled_voicing_entropy_bits']:>16.3f}"
+    print(prow)
+    print(erow)
+    print("=" * 72)
+    print("Collapse signature: LOW pitch/voicing entropy + LOW distinct ratio")
+    print("                    + HIGH n-gram repeat. Compare probe vs full corpus.")
+
+    if args.json_out:
+        Path(args.json_out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.json_out).write_text(json.dumps(results, indent=2))
+        print(f"\nFull results -> {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mps_smoke_test.py
+++ b/scripts/mps_smoke_test.py
@@ -1,0 +1,198 @@
+"""
+MPS smoke test for the Music Transformer (incl. rpr=True custom attention).
+
+Run this ON YOUR MAC TERMINAL (not inside a sandbox), where Metal is visible:
+
+    cd /Users/ohhalim/git_box/fine_tuning_art-tatum_midi_solo
+    ./.venv/bin/python scripts/mps_smoke_test.py
+
+It checks, on the MPS device:
+  1. model builds and moves to mps
+  2. forward pass runs and returns finite logits
+  3. loss + backward + optimizer step run (grads are finite)
+  4. a short timing comparison vs CPU
+
+If any step raises a "not implemented for MPS" error, that op is the blocker
+and we fall back to CPU (or add PYTORCH_ENABLE_MPS_FALLBACK=1). If all pass,
+MPS training is safe.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "music_transformer"))
+sys.path.insert(0, str(ROOT / "music_transformer" / "third_party"))
+
+from model.music_transformer import MusicTransformer  # noqa: E402
+from model.loss import SmoothCrossEntropyLoss  # noqa: E402
+from utilities.constants import VOCAB_SIZE, TOKEN_PAD  # noqa: E402
+import utilities.device as devmod  # noqa: E402
+
+
+def build_model(rpr: bool):
+    return MusicTransformer(
+        n_layers=6, num_heads=8, d_model=512,
+        dim_feedforward=1024, max_sequence=512, rpr=rpr,
+    )
+
+
+def one_step(device_str: str, rpr: bool, seq_len: int = 256, batch: int = 2, steps: int = 3):
+    """Run `steps` train steps on the given device. Returns (ok, elapsed, msg)."""
+    dev = torch.device(device_str)
+    torch.manual_seed(0)
+    model = build_model(rpr).to(dev)
+    model.train()
+    loss_fn = SmoothCrossEntropyLoss(0.1, VOCAB_SIZE, ignore_index=TOKEN_PAD)
+    opt = torch.optim.AdamW(model.parameters(), lr=2e-4)
+
+    x = torch.randint(0, VOCAB_SIZE, (batch, seq_len), device=dev)
+    y = torch.randint(0, VOCAB_SIZE, (batch, seq_len), device=dev)
+
+    t0 = time.time()
+    last_loss = None
+    for _ in range(steps):
+        opt.zero_grad()
+        out = model(x)                       # forward (calls get_device() internally for mask)
+        loss = loss_fn(out.view(-1, out.size(-1)), y.view(-1))
+        loss.backward()
+        # finite-grad check
+        bad = [n for n, p in model.named_parameters()
+               if p.grad is not None and not torch.isfinite(p.grad).all()]
+        if bad:
+            return False, time.time() - t0, f"non-finite grads in {len(bad)} params (first: {bad[0]})"
+        opt.step()
+        last_loss = float(loss.detach().cpu())
+    if dev.type == "mps":
+        torch.mps.synchronize()
+    return True, time.time() - t0, f"final loss={last_loss:.4f}"
+
+
+def scale_benchmark():
+    """Time MPS vs CPU at realistic TRAINING shapes to find the crossover.
+
+    The default smoke shapes (seq 256, batch 2) are tiny — MPS overhead
+    dominates there. Real D0-(b) training uses larger shapes where MPS may
+    win. This measures steps/sec at a few (batch, seq) points so you can
+    pick the device with data, not a guess.
+    """
+    if not torch.backends.mps.is_available():
+        return
+    print("\n" + "=" * 64)
+    print("SCALE BENCHMARK (rpr=True) — steps/sec, higher is better")
+    print(f"{'batch':>5} {'seq':>5} {'MPS s/step':>12} {'CPU s/step':>12} {'winner':>8}")
+    print("-" * 64)
+    # warm up MPS once (first-ever MPS op pays a one-time compile cost)
+    try:
+        one_step("mps", True, seq_len=128, batch=1, steps=1)
+    except Exception:
+        pass
+    for batch, seq in [(4, 256), (8, 512), (8, 1024)]:
+        row = {}
+        for dev in ("mps", "cpu"):
+            try:
+                if dev == "cpu":
+                    devmod.use_cuda(False)
+                ok, el, _ = one_step(dev, True, seq_len=seq, batch=batch, steps=4)
+                if dev == "cpu":
+                    devmod.use_cuda(True)
+                row[dev] = el / 4 if ok else None
+            except Exception as e:
+                if dev == "cpu":
+                    devmod.use_cuda(True)
+                row[dev] = None
+                print(f"  ({dev} raised at batch={batch} seq={seq}: {type(e).__name__})")
+        m, c = row.get("mps"), row.get("cpu")
+        win = "?" if (m is None or c is None) else ("MPS" if m < c else "CPU")
+        ms = f"{m:.3f}" if m else "FAIL"
+        cs = f"{c:.3f}" if c else "FAIL"
+        print(f"{batch:>5} {seq:>5} {ms:>12} {cs:>12} {win:>8}")
+    print("=" * 64)
+    print("Use the device that wins at YOUR training shape (batch/seq).")
+    print("Rule of thumb: MPS wins as batch*seq grows; CPU wins for tiny probes.")
+
+
+def main() -> int:
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scale", action="store_true",
+                    help="Also run the MPS-vs-CPU timing sweep at training shapes.")
+    cli = ap.parse_args()
+
+    print("=" * 64)
+    print("torch", torch.__version__)
+    print("mps built    :", torch.backends.mps.is_built())
+    print("mps available:", torch.backends.mps.is_available())
+    print("get_device() default ->", devmod.get_device())
+    print("=" * 64)
+
+    if not torch.backends.mps.is_available():
+        print("\nMPS not available in THIS process. If you are running this in a")
+        print("normal Mac terminal on macOS 14+/Apple Silicon, check your torch build.")
+        print("(Inside the assistant sandbox MPS is intentionally hidden — that is expected.)")
+        return 1
+
+    results = {}
+    for rpr in (False, True):
+        tag = f"rpr={rpr}"
+        print(f"\n### {tag} ###")
+        # MPS
+        try:
+            ok, el, msg = one_step("mps", rpr)
+            print(f"  MPS : {'OK ' if ok else 'FAIL'}  {el:.2f}s  {msg}")
+            results[(tag, "mps")] = (ok, el)
+        except Exception as e:
+            print(f"  MPS : FAIL  raised: {type(e).__name__}: {e}")
+            results[(tag, "mps")] = (False, None)
+        # CPU baseline for the same shape
+        try:
+            devmod.use_cuda(False)               # force get_device()->cpu during CPU run
+            ok, el, msg = one_step("cpu", rpr)
+            devmod.use_cuda(True)
+            print(f"  CPU : {'OK ' if ok else 'FAIL'}  {el:.2f}s  {msg}")
+            results[(tag, "cpu")] = (ok, el)
+        except Exception as e:
+            devmod.use_cuda(True)
+            print(f"  CPU : FAIL  raised: {type(e).__name__}: {e}")
+            results[(tag, "cpu")] = (False, None)
+
+    # verdict
+    print("\n" + "=" * 64)
+    mps_ok = all(results.get((f"rpr={r}", "mps"), (False,))[0] for r in (False, True))
+    if mps_ok:
+        # relative speed at the (tiny) smoke shape — NOT the training shape
+        m = results.get(("rpr=True", "mps"), (True, None))[1]
+        c = results.get(("rpr=True", "cpu"), (True, None))[1]
+        if m and c:
+            faster = "MPS" if m < c else "CPU"
+            ratio = (c / m) if m < c else (m / c)
+            rel = f"At this tiny smoke shape, {faster} is {ratio:.1f}x faster."
+        else:
+            rel = ""
+        print("VERDICT: MPS is COMPATIBLE for rpr=True (no unsupported ops).")
+        print(f"         {rel}")
+        print("         Small model + small batch => MPS overhead can lose to CPU.")
+        print("         Decide per experiment:")
+        print("           - tiny probe (D0-a): use --device cpu")
+        print("           - full corpus (D0-b): run --scale below, pick the winner")
+        print("         Timing at real training shapes:")
+        print("           ./.venv/bin/python scripts/mps_smoke_test.py --scale")
+    else:
+        print("VERDICT: at least one op is not MPS-compatible.")
+        print("Options: (a) run on CPU, or (b) retry with env")
+        print("         PYTORCH_ENABLE_MPS_FALLBACK=1 ./.venv/bin/python scripts/mps_smoke_test.py")
+        print("         (falls unsupported ops back to CPU — slower but works).")
+    print("=" * 64)
+
+    if cli.scale and mps_ok:
+        scale_benchmark()
+    return 0 if mps_ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/train_qlora.py
+++ b/scripts/train_qlora.py
@@ -25,8 +25,16 @@ from torch.optim import AdamW
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from tqdm import tqdm
 
-# Add music_transformer to path
-SCRIPT_DIR = Path(__file__).parent.parent
+# Add music_transformer to path. Walk up from this file until we find the
+# repo root that actually contains music_transformer/ (robust to the script
+# living in scripts/ or archive/scripts/).
+def _find_repo_root(start: Path) -> Path:
+    for cand in [start, *start.parents]:
+        if (cand / "music_transformer").is_dir():
+            return cand
+    return start.parent.parent  # fallback to original behaviour
+
+SCRIPT_DIR = _find_repo_root(Path(__file__).resolve())
 sys.path.insert(0, str(SCRIPT_DIR / "music_transformer"))
 sys.path.insert(0, str(SCRIPT_DIR / "music_transformer" / "third_party"))
 
@@ -34,6 +42,8 @@ from model.music_transformer import MusicTransformer
 from model.loss import SmoothCrossEntropyLoss
 from utilities.constants import TOKEN_COND_SEP, TOKEN_PAD, VOCAB_SIZE
 
+# checkpoint_utils lives next to this script; make sure its dir is importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 try:
     from checkpoint_utils import load_state_dict_with_token_resize
 except ModuleNotFoundError:
@@ -470,12 +480,38 @@ def main():
     
     # Output
     parser.add_argument("--output_dir", type=str, default="./checkpoints/jazz_lora")
-    
+
+    # Device: auto -> cuda, else mps (Apple Silicon), else cpu
+    parser.add_argument(
+        "--device", type=str, default="auto",
+        choices=["auto", "cuda", "mps", "cpu"],
+        help="Compute device. 'auto' prefers CUDA, then MPS, then CPU.",
+    )
+
     args = parser.parse_args()
     set_seed(args.seed)
-    
-    # Device
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Device selection. Must stay consistent with the model's internal
+    # get_device() (music_transformer.py builds the causal mask via get_device()),
+    # so we drive both through utilities.device.
+    from utilities.device import get_device, use_cuda, mps_device
+    if args.device == "cpu":
+        use_cuda(False)
+    elif args.device == "cuda":
+        if not torch.cuda.is_available():
+            raise SystemExit("--device cuda requested but CUDA is not available.")
+        use_cuda(True)
+    elif args.device == "mps":
+        if mps_device() is None:
+            raise SystemExit(
+                "--device mps requested but MPS is not available. "
+                "Need Apple Silicon + macOS 14+ and an MPS-enabled torch build. "
+                "Run scripts/mps_smoke_test.py to diagnose."
+            )
+        use_cuda(True)  # get_device() falls through CUDA(None) -> MPS
+    else:  # auto
+        use_cuda(True)
+    device = get_device()
     print(f"Using device: {device}")
     
     # Create output directory


### PR DESCRIPTION
## What

Enables local training on Apple Silicon (MPS) and adds a diversity-metrics
harness for diagnosing the personalization fine-tuning bottleneck.

Closes #1442.

## Why

Cross-entropy/perplexity cannot see voicing-diversity collapse or harmonic
repetition. A data + code audit showed the model trains from scratch (no
pretrained symbolic prior) and that only a 16-shard probe ever entered
training while 2,703 clean files went unused. To test "more data restores
diversity" locally we need usable local GPU + distributional metrics.

## Changes

**`music_transformer/utilities/device.py`**
- `get_device()` prefers CUDA -> MPS -> CPU (was CUDA/CPU only).
- Adds `TORCH_MPS_DEVICE` detection + `mps_device()`; `FORCE_CPU=1` to disable.
- CUDA path unchanged (backward compatible).

**`scripts/train_qlora.py`**
- New `--device {auto,cuda,mps,cpu}`, driven through `utilities.device.use_cuda()`
  so the model-internal `get_device()` (causal mask) matches the training device
  — avoids an MPS device-mismatch crash.
- Robust repo-root resolution + script-dir on `sys.path` (runs from `scripts/`
  or `archive/scripts/`).

**`scripts/mps_smoke_test.py`** (new)
- forward+backward+step on MPS for `rpr={False,True}`; `--scale` sweeps MPS vs
  CPU steps/sec at training shapes to find the crossover.

**`scripts/diversity_metrics.py`** (new)
- Decodes legacy performance tokens -> note events; pitch-class/voicing entropy,
  distinct-voicing ratio, n-gram repetition, note density, IOI CV.
- Accepts `.npy` shards or generated `.mid`; compares two sets.

**`MPS_TRAINING_GUIDE.md`** (new)
- Local MPS run instructions, smoke-test gate, D0 commands, troubleshooting.

## Validation

- CPU end-to-end run of `train_qlora.py` (16 shards) completes: LoRA attach ->
  data load (16 train / 2 val) -> train -> val loss -> checkpoint saved.
- MPS smoke test on-device: `rpr=True` forward+backward+step OK, no unsupported
  ops. At the tiny smoke shape CPU is ~2.5x faster (dispatch overhead) — use
  `--scale` to pick the device for full-corpus training.
- `diversity_metrics.py` on real data (probe vs jazz_processed): voicing entropy
  4.24 vs 5.12; pooled unique voicings 254 vs 513; voicing 4-gram repeat
  0.234 vs 0.123 — the collapse signature is measurable.

## Test plan (reviewer / local)

```
./.venv/bin/python scripts/mps_smoke_test.py          # compatibility gate
./.venv/bin/python scripts/mps_smoke_test.py --scale  # device choice
./.venv/bin/python scripts/diversity_metrics.py \
    --npy_dir data/roles/lead/tokenized/train \
    --compare_dir data/jazz_processed/train --labels probe full
```

## Risk

Low. CUDA/CPU behavior unchanged; new script files are additive; the
`train_qlora.py` change is opt-in via `--device` (default `auto` preserves prior
CUDA-first behavior).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple Silicon MPS support for training, with automatic CUDA/MPS/CPU device selection.
  * Added a command-line device option for choosing CUDA, MPS, CPU, or automatic selection.
  * Added an MPS compatibility smoke test with performance benchmarking and fallback guidance.
  * Added diversity metrics for analyzing generated music from token sequences or MIDI files.

* **Documentation**
  * Added a comprehensive local MPS training guide, troubleshooting matrix, experiments, and evaluation recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->