### PR TITLE
fix: D1 하니스 measure 인자 오류 (--output → --json_out)

### DIFF
--- a/scripts/run_d1_experiment.sh
+++ b/scripts/run_d1_experiment.sh
@@ -117,7 +117,7 @@ measure_arm () {
   "${PY}" scripts/diversity_metrics.py \
     --npy_dir "${base}/samples" \
     --compare_dir "${SAMP_A}" \
-    --output "${json}"
+    --json_out "${json}"
 }
 
 # ---- 실행 ---------------------------------------------------------------------


### PR DESCRIPTION
첫 D1 실행에서 발견. Arm C train/gen은 정상, measure만 인자명 불일치로 실패 → 수정 후 재실행 확인 완료. Ref #1449