### PR TITLE
fix: D4 하니스 none 팔 nounset 버그 (bash 3.2 빈 배열 펼침)

### DIFF
--- a/scripts/run_d4_experiment.sh
+++ b/scripts/run_d4_experiment.sh
@@ -59,7 +59,7 @@ gen_arm () {
   [ -n "${primer}" ] && cond_arg=(--conditioning_midi "${primer}")
   "${PY}" scripts/generate.py \
     --lora_path "${BASE_CKPT}" \
-    "${cond_arg[@]}" \
+    ${cond_arg[@]+"${cond_arg[@]}"} \
     --num_samples "${NUM_SAMPLES}" \
     --length "${GEN_LENGTH}" \
     --temperature "${GEN_TEMP}" \


### PR DESCRIPTION
## 무엇
D4 실험 하니스의 `none`(무프라이머) 팔이 macOS bash 3.2에서 `set -u` + 빈 배열 조합으로 중단되던 버그를 1줄 수정.

Closes #1466

## 왜
- macOS 기본 bash 3.2.57 + `set -euo pipefail`
- `none` 팔은 `cond_arg=()` 빈 배열 → `"${cond_arg[@]}"` 펼침이 `unbound variable` 에러
- base/twohand/chordal(프라이머 있음)은 정상 완료, none만 실패

## 변경
`scripts/run_d4_experiment.sh` 62행:
`"${cond_arg[@]}"` → `${cond_arg[@]+"${cond_arg[@]}"}` (bash 3.2 호환 빈 배열 펼침)

## 검증
- `bash -n` 문법 통과
- `set -euo pipefail; a=(); echo ${a[@]+"${a[@]}"}` → 크래시 없음 확인

## 이어하기 (결과는 별도 PR)
```
STAGE=gen ARMS=none bash scripts/run_d4_experiment.sh
STAGE=measure ARMS="twohand chordal none" bash scripts/run_d4_experiment.sh
```
